### PR TITLE
Fix Prayer Group Ordering

### DIFF
--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupApi.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupApi.java
@@ -3,6 +3,7 @@ package com.kevin.prayerappservice.group;
 import com.kevin.prayerappservice.group.models.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,7 +14,7 @@ import java.sql.SQLException;
 public interface PrayerGroupApi {
     @PostMapping(value = "", produces = {"application/json"}, consumes = { "application/json" })
     @Operation(summary = "Creates prayer group")
-    ResponseEntity<PrayerGroupModel> createPrayerGroup(@RequestHeader("Authorization") String authorizationHeader,  @RequestBody CreatePrayerGroupRequest createPrayerGroupRequest);
+    ResponseEntity<PrayerGroupModel> createPrayerGroup(@RequestHeader("Authorization") String authorizationHeader, @Valid @RequestBody CreatePrayerGroupRequest createPrayerGroupRequest);
 
     @GetMapping(value="validate-name")
     @Operation(summary = "Validates group name")

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupApi.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupApi.java
@@ -30,7 +30,7 @@ public interface PrayerGroupApi {
 
     @PostMapping("/{prayerGroupId}/user/{userId}")
     @Operation(summary = "Adds prayer group user")
-    ResponseEntity<PrayerGroupUserModel> addPrayerGroupUser(@RequestHeader("Authorization") String authorizationHeader, @PathVariable int prayerGroupId, @PathVariable int userId);
+    ResponseEntity<PrayerGroupUserModel> addPrayerGroupUser(@RequestHeader("Authorization") String authorizationHeader, @PathVariable int prayerGroupId, @PathVariable int userId, @Valid @RequestBody PrayerGroupUserCreateRequest createRequest);
 
     @DeleteMapping("/{prayerGroupId}/user/{userId}")
     @Operation(summary = "Removes a prayer group user")

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupController.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupController.java
@@ -42,8 +42,8 @@ public class PrayerGroupController implements PrayerGroupApi {
     }
 
     @Override
-    public ResponseEntity<PrayerGroupUserModel> addPrayerGroupUser(String authorizationHeader, int prayerGroupId, int userId){
-        PrayerGroupUserModel prayerGroupUser = prayerGroupService.addPrayerGroupUser(authorizationHeader, prayerGroupId, userId);
+    public ResponseEntity<PrayerGroupUserModel> addPrayerGroupUser(String authorizationHeader, int prayerGroupId, int userId, PrayerGroupUserCreateRequest createRequest){
+        PrayerGroupUserModel prayerGroupUser = prayerGroupService.addPrayerGroupUser(authorizationHeader, prayerGroupId, userId, createRequest);
         return new ResponseEntity<>(prayerGroupUser, HttpStatus.OK);
     }
 

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupJdbcRepository.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupJdbcRepository.java
@@ -4,6 +4,7 @@ import com.kevin.prayerappservice.group.constants.PrayerGroupRole;
 import com.kevin.prayerappservice.group.dtos.*;
 
 import java.sql.SQLException;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface PrayerGroupJdbcRepository {
@@ -11,6 +12,6 @@ public interface PrayerGroupJdbcRepository {
     List<PrayerGroupSummaryDTO> getPrayerGroupSummariesByUserId(int userId);
     PrayerGroupDTO getPrayerGroup(int prayerGroupId, int userId);
     List<PrayerGroupUserDTO> getPrayerGroupUsers(int prayerGroupId, List<PrayerGroupRole> prayerGroupRoles);
-    void updatePrayerGroupUsers(int prayerGroupId, PrayerGroupUserUpdateItem[] prayerGroupUserUpdateItems) throws SQLException;
+    void updatePrayerGroupUsers(int prayerGroupId, PrayerGroupUserUpdateItem[] prayerGroupUserUpdateItems, OffsetDateTime updateDate) throws SQLException;
     List<PrayerGroupSummaryDTO> searchPrayerGroups(String groupNameQuery, int maxNumResults);
 }

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupJdbcRepositoryImpl.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupJdbcRepositoryImpl.java
@@ -12,6 +12,7 @@ import javax.sql.DataSource;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -64,15 +65,16 @@ public class PrayerGroupJdbcRepositoryImpl implements PrayerGroupJdbcRepository 
         return jdbcTemplate.query(sql, params, new BeanPropertyRowMapper<>(PrayerGroupUserDTO.class));
     }
 
-    public void updatePrayerGroupUsers(int prayerGroupId, PrayerGroupUserUpdateItem[] prayerGroupUserUpdateItems) throws SQLException {
+    public void updatePrayerGroupUsers(int prayerGroupId, PrayerGroupUserUpdateItem[] prayerGroupUserUpdateItems, OffsetDateTime updateDate) throws SQLException {
         Connection connection = dataSource.getConnection();
         Array updateItemsArray = connection.createArrayOf("prayer_group_user_update_item", prayerGroupUserUpdateItems);
 
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("prayer_group_id", prayerGroupId);
         params.addValue("updated_users", updateItemsArray);
+        params.addValue("update_date", updateDate);
 
-        String sql = "CALL update_prayer_group_users(:prayer_group_id, :updated_users);";
+        String sql = "CALL update_prayer_group_users(:prayer_group_id, :updated_users, :update_date);";
         jdbcTemplate.update(sql, params);
     }
 

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupJdbcRepositoryImpl.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupJdbcRepositoryImpl.java
@@ -28,7 +28,7 @@ public class PrayerGroupJdbcRepositoryImpl implements PrayerGroupJdbcRepository 
 
     public CreatedPrayerGroupDTO createPrayerGroup(CreatePrayerGroupRequestDTO createPrayerGroupRequest) {
         String sql = "SELECT * FROM create_prayer_group(:creatorUserId, :newGroupName, CAST(:groupDescription AS " +
-                "TEXT), CAST(:groupRules AS TEXT), :groupVisibility, :avatarFileId, :bannerFileId)";
+                "TEXT), CAST(:groupRules AS TEXT), :groupVisibility, :avatarFileId, :bannerFileId, :createdDate)";
         BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(createPrayerGroupRequest);
 
         return jdbcTemplate.queryForObject(

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupService.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupService.java
@@ -21,6 +21,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.sql.SQLException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,9 +53,11 @@ public class PrayerGroupService {
         VisibilityLevel visibilityLevel =
                 Optional.ofNullable(prayerGroupRequest.getVisibilityLevel()).orElse(VisibilityLevel.PUBLIC);
 
+        OffsetDateTime createdDate = Optional.ofNullable(prayerGroupRequest.getCreatedDate()).orElse(OffsetDateTime.now());
+
         CreatePrayerGroupRequestDTO createPrayerGroupRequestDTO = new CreatePrayerGroupRequestDTO(userId,
                 prayerGroupRequest.getGroupName(), prayerGroupRequest.getDescription(), prayerGroupRequest.getRules(),
-                visibilityLevel.toString(), prayerGroupRequest.getAvatarFileId(), prayerGroupRequest.getBannerFileId());
+                visibilityLevel.toString(), prayerGroupRequest.getAvatarFileId(), prayerGroupRequest.getBannerFileId(), createdDate);
 
         CreatedPrayerGroupDTO createdPrayerGroupDTO =
                 prayerGroupRepository.createPrayerGroup(createPrayerGroupRequestDTO);
@@ -133,7 +136,7 @@ public class PrayerGroupService {
         return getPrayerGroup(authorizationHeader, prayerGroupId);
     }
 
-    public PrayerGroupUserModel addPrayerGroupUser(String authorizationHeader, int prayerGroupId, int userId) {
+    public PrayerGroupUserModel addPrayerGroupUser(String authorizationHeader, int prayerGroupId, int userId, PrayerGroupUserCreateRequest createRequest) {
         PrayerGroup prayerGroup = prayerGroupRepository.findById(prayerGroupId)
                 .orElseThrow(() -> new DataValidationException(String.format(PrayerGroupErrorMessages.CANNOT_FIND_PRAYER_GROUP, prayerGroupId)));
 
@@ -150,8 +153,10 @@ public class PrayerGroupService {
             throw new DataValidationException(PrayerGroupErrorMessages.CANNOT_ADD_TO_PRIVATE_GROUP);
         }
 
+        OffsetDateTime joinDate = Optional.ofNullable(createRequest.getJoinDate()).orElse(OffsetDateTime.now());
+
         User user = entityManager.getReference(User.class, userId);
-        PrayerGroupUser newPrayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser newPrayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER, joinDate);
 
         PrayerGroupUser createdPrayerGroupUser = prayerGroupUserRepository.save(newPrayerGroupUser);
         return prayerGroupMapper.prayerGroupUserToPrayerGroupUserModel(createdPrayerGroupUser);

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupService.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupService.java
@@ -5,10 +5,7 @@ import com.kevin.prayerappservice.common.SortConfig;
 import com.kevin.prayerappservice.common.SortDirection;
 import com.kevin.prayerappservice.exceptions.DataValidationException;
 import com.kevin.prayerappservice.file.entities.MediaFile;
-import com.kevin.prayerappservice.group.constants.PrayerGroupErrorMessages;
-import com.kevin.prayerappservice.group.constants.PrayerGroupRole;
-import com.kevin.prayerappservice.group.constants.PrayerGroupUserSortField;
-import com.kevin.prayerappservice.group.constants.VisibilityLevel;
+import com.kevin.prayerappservice.group.constants.*;
 import com.kevin.prayerappservice.group.dtos.*;
 import com.kevin.prayerappservice.group.entities.PrayerGroup;
 import com.kevin.prayerappservice.group.entities.PrayerGroupUser;
@@ -80,8 +77,10 @@ public class PrayerGroupService {
     public List<PrayerGroupSummaryModel> getPrayerGroupSummariesByUser(int userId) {
         List<PrayerGroupSummaryDTO> prayerGroupSummaries =
                 prayerGroupRepository.getPrayerGroupSummariesByUserId(userId);
+
         return prayerGroupSummaries.stream()
                 .map(prayerGroupMapper::prayerGroupSummaryDTOToPrayerGroupSummaryModel)
+                .sorted(this::comparePrayerGroupSummaries)
                 .toList();
     }
 
@@ -254,5 +253,20 @@ public class PrayerGroupService {
             case PrayerGroupUserSortField.FULL_NAME ->
                     userModelA.getFullName().compareTo(userModelB.getFullName()) * sortCoefficient;
         };
+    }
+
+    private int comparePrayerGroupSummaries(PrayerGroupSummaryModel summaryModelA, PrayerGroupSummaryModel summaryModelB){
+        JoinStatus joinStatusA = summaryModelA.getJoinStatus();
+        JoinStatus joinStatusB = summaryModelB.getJoinStatus();
+
+        if(joinStatusA == JoinStatus.JOINED && joinStatusB != JoinStatus.JOINED){
+            return -1;
+        }
+
+        if(joinStatusB == JoinStatus.JOINED && joinStatusA != JoinStatus.JOINED){
+            return 1;
+        }
+
+        return summaryModelA.getAddedDate().compareTo(summaryModelB.getAddedDate());
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/PrayerGroupService.java
+++ b/src/main/java/com/kevin/prayerappservice/group/PrayerGroupService.java
@@ -204,8 +204,10 @@ public class PrayerGroupService {
             throw new DataValidationException(PrayerGroupErrorMessages.PRAYER_GROUP_MUST_HAVE_ADMIN);
         }
 
+        OffsetDateTime updateDate = Optional.ofNullable(prayerGroupUserUpdateRequest.getUpdateDate()).orElse(OffsetDateTime.now());
+
         PrayerGroupUserUpdateItem[] prayerGroupUserUpdateItems = mapPrayerGroupUserUpdateModelsToUpdateItems(prayerGroupId, prayerGroupUserUpdateModels);
-        prayerGroupRepository.updatePrayerGroupUsers(prayerGroupId, prayerGroupUserUpdateItems);
+        prayerGroupRepository.updatePrayerGroupUsers(prayerGroupId, prayerGroupUserUpdateItems, updateDate);
 
         SortConfig<PrayerGroupUserSortField> sortConfig = new SortConfig<>(PrayerGroupUserSortField.USERNAME, SortDirection.ASCENDING);
         List<PrayerGroupRole> prayerGroupRoles = List.of(new PrayerGroupRole[]{PrayerGroupRole.ADMIN, PrayerGroupRole.MEMBER});

--- a/src/main/java/com/kevin/prayerappservice/group/dtos/CreatePrayerGroupRequestDTO.java
+++ b/src/main/java/com/kevin/prayerappservice/group/dtos/CreatePrayerGroupRequestDTO.java
@@ -12,7 +12,7 @@ public class CreatePrayerGroupRequestDTO {
     private Integer bannerFileId;
     private OffsetDateTime createdDate;
 
-    public CreatePrayerGroupRequestDTO(int creatorUserId, String newGroupName, String groupDescription, String groupRules, String groupVisibility, Integer avatarFileId, Integer bannerFileId, OffsetDateTime createdDates) {
+    public CreatePrayerGroupRequestDTO(int creatorUserId, String newGroupName, String groupDescription, String groupRules, String groupVisibility, Integer avatarFileId, Integer bannerFileId, OffsetDateTime createdDate) {
         this.creatorUserId = creatorUserId;
         this.newGroupName = newGroupName;
         this.groupDescription = groupDescription;
@@ -20,6 +20,7 @@ public class CreatePrayerGroupRequestDTO {
         this.groupVisibility = groupVisibility;
         this.avatarFileId = avatarFileId;
         this.bannerFileId = bannerFileId;
+        this.createdDate = createdDate;
     }
 
     public int getCreatorUserId() {

--- a/src/main/java/com/kevin/prayerappservice/group/dtos/CreatePrayerGroupRequestDTO.java
+++ b/src/main/java/com/kevin/prayerappservice/group/dtos/CreatePrayerGroupRequestDTO.java
@@ -1,5 +1,7 @@
 package com.kevin.prayerappservice.group.dtos;
 
+import java.time.OffsetDateTime;
+
 public class CreatePrayerGroupRequestDTO {
     private int creatorUserId;
     private String newGroupName;
@@ -8,8 +10,9 @@ public class CreatePrayerGroupRequestDTO {
     private String groupVisibility;
     private Integer avatarFileId;
     private Integer bannerFileId;
+    private OffsetDateTime createdDate;
 
-    public CreatePrayerGroupRequestDTO(int creatorUserId, String newGroupName, String groupDescription, String groupRules, String groupVisibility, Integer avatarFileId, Integer bannerFileId) {
+    public CreatePrayerGroupRequestDTO(int creatorUserId, String newGroupName, String groupDescription, String groupRules, String groupVisibility, Integer avatarFileId, Integer bannerFileId, OffsetDateTime createdDates) {
         this.creatorUserId = creatorUserId;
         this.newGroupName = newGroupName;
         this.groupDescription = groupDescription;
@@ -73,5 +76,13 @@ public class CreatePrayerGroupRequestDTO {
 
     public void setBannerFileId(Integer bannerFileId) {
         this.bannerFileId = bannerFileId;
+    }
+
+    public OffsetDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(OffsetDateTime createdDate) {
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/dtos/CreatedPrayerGroupDTO.java
+++ b/src/main/java/com/kevin/prayerappservice/group/dtos/CreatedPrayerGroupDTO.java
@@ -2,6 +2,8 @@ package com.kevin.prayerappservice.group.dtos;
 
 import com.kevin.prayerappservice.group.constants.VisibilityLevel;
 
+import java.time.OffsetDateTime;
+
 public class CreatedPrayerGroupDTO {
     private int prayerGroupId;
     private String groupName;
@@ -19,10 +21,11 @@ public class CreatedPrayerGroupDTO {
     private Integer adminImageFileId;
     private String adminImageFileName;
     private String adminImageFileUrl;
+    private OffsetDateTime adminJoinDate;
 
     public CreatedPrayerGroupDTO(){}
 
-    public CreatedPrayerGroupDTO(int prayerGroupId, String groupName, String description, String rules, VisibilityLevel visibilityLevel, Integer avatarFileId, String groupAvatarFileName, String groupAvatarFileUrl, Integer bannerFileId, String groupBannerFileName, String groupBannerFileUrl, int adminUserId, String adminFullName, Integer adminImageFileId, String adminImageFileName, String adminImageFileUrl) {
+    public CreatedPrayerGroupDTO(int prayerGroupId, String groupName, String description, String rules, VisibilityLevel visibilityLevel, Integer avatarFileId, String groupAvatarFileName, String groupAvatarFileUrl, Integer bannerFileId, String groupBannerFileName, String groupBannerFileUrl, int adminUserId, String adminFullName, Integer adminImageFileId, String adminImageFileName, String adminImageFileUrl, OffsetDateTime adminJoinDate) {
         this.prayerGroupId = prayerGroupId;
         this.groupName = groupName;
         this.description = description;
@@ -39,6 +42,7 @@ public class CreatedPrayerGroupDTO {
         this.adminImageFileId = adminImageFileId;
         this.adminImageFileName = adminImageFileName;
         this.adminImageFileUrl = adminImageFileUrl;
+        this.adminJoinDate = adminJoinDate;
     }
 
     public int getPrayerGroupId() {
@@ -167,5 +171,13 @@ public class CreatedPrayerGroupDTO {
 
     public void setAdminImageFileUrl(String adminImageFileUrl) {
         this.adminImageFileUrl = adminImageFileUrl;
+    }
+
+    public OffsetDateTime getAdminJoinDate() {
+        return adminJoinDate;
+    }
+
+    public void setAdminJoinDate(OffsetDateTime adminJoinDate) {
+        this.adminJoinDate = adminJoinDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/dtos/PrayerGroupDTO.java
+++ b/src/main/java/com/kevin/prayerappservice/group/dtos/PrayerGroupDTO.java
@@ -1,5 +1,7 @@
 package com.kevin.prayerappservice.group.dtos;
 
+import java.time.OffsetDateTime;
+
 public class PrayerGroupDTO {
     private int prayerGroupId;
     private String groupName;
@@ -17,11 +19,12 @@ public class PrayerGroupDTO {
     private String prayerGroupRole;
     private Integer joinRequestId;
     private Integer joinRequestCount;
+    private OffsetDateTime userJoinDate;
 
     public PrayerGroupDTO() {
     }
 
-    public PrayerGroupDTO(int prayerGroupId, String groupName, String description, String rules, String visibilityLevel, Integer avatarFileId, String avatarFileName, String avatarFileUrl, String avatarFileType, Integer bannerFileId, String bannerFileName, String bannerFileUrl, String bannerFileType, String prayerGroupRole, Integer joinRequestId, Integer joinRequestCount) {
+    public PrayerGroupDTO(int prayerGroupId, String groupName, String description, String rules, String visibilityLevel, Integer avatarFileId, String avatarFileName, String avatarFileUrl, String avatarFileType, Integer bannerFileId, String bannerFileName, String bannerFileUrl, String bannerFileType, String prayerGroupRole, Integer joinRequestId, Integer joinRequestCount, OffsetDateTime userJoinDate) {
         this.prayerGroupId = prayerGroupId;
         this.groupName = groupName;
         this.description = description;
@@ -38,6 +41,7 @@ public class PrayerGroupDTO {
         this.prayerGroupRole = prayerGroupRole;
         this.joinRequestId = joinRequestId;
         this.joinRequestCount = joinRequestCount;
+        this.userJoinDate = userJoinDate;
     }
 
     public PrayerGroupDTO(int prayerGroupId, String groupName, String description, String rules,
@@ -175,5 +179,13 @@ public class PrayerGroupDTO {
 
     public void setJoinRequestCount(Integer joinRequestCount) {
         this.joinRequestCount = joinRequestCount;
+    }
+
+    public OffsetDateTime getUserJoinDate() {
+        return userJoinDate;
+    }
+
+    public void setUserJoinDate(OffsetDateTime userJoinDate) {
+        this.userJoinDate = userJoinDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/dtos/PrayerGroupSummaryDTO.java
+++ b/src/main/java/com/kevin/prayerappservice/group/dtos/PrayerGroupSummaryDTO.java
@@ -2,6 +2,8 @@ package com.kevin.prayerappservice.group.dtos;
 
 import com.kevin.prayerappservice.group.constants.JoinStatus;
 
+import java.time.OffsetDateTime;
+
 public class PrayerGroupSummaryDTO {
     private int prayerGroupId;
     private String groupName;
@@ -10,10 +12,11 @@ public class PrayerGroupSummaryDTO {
     private String fileUrl;
     private String fileType;
     private JoinStatus joinStatus;
+    private OffsetDateTime addedDate;
 
     public PrayerGroupSummaryDTO(){}
 
-    public PrayerGroupSummaryDTO(int prayerGroupId, String groupName, Integer mediaFileId, String fileName, String fileUrl, String fileType, JoinStatus joinStatus) {
+    public PrayerGroupSummaryDTO(int prayerGroupId, String groupName, Integer mediaFileId, String fileName, String fileUrl, String fileType, JoinStatus joinStatus, OffsetDateTime addedDate) {
         this.prayerGroupId = prayerGroupId;
         this.groupName = groupName;
         this.mediaFileId = mediaFileId;
@@ -21,6 +24,7 @@ public class PrayerGroupSummaryDTO {
         this.fileUrl = fileUrl;
         this.fileType = fileType;
         this.joinStatus = joinStatus;
+        this.addedDate = addedDate;
     }
 
     public int getPrayerGroupId() {
@@ -77,5 +81,13 @@ public class PrayerGroupSummaryDTO {
 
     public void setJoinStatus(JoinStatus joinStatus){
         this.joinStatus = joinStatus;
+    }
+
+    public OffsetDateTime getAddedDate() {
+        return addedDate;
+    }
+
+    public void setAddedDate(OffsetDateTime addedDate) {
+        this.addedDate = addedDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/dtos/PrayerGroupUserDTO.java
+++ b/src/main/java/com/kevin/prayerappservice/group/dtos/PrayerGroupUserDTO.java
@@ -1,5 +1,7 @@
 package com.kevin.prayerappservice.group.dtos;
 
+import java.time.OffsetDateTime;
+
 public class PrayerGroupUserDTO {
     private int userId;
     private String fullName;
@@ -9,10 +11,11 @@ public class PrayerGroupUserDTO {
     private String fileName;
     private String fileUrl;
     private String fileType;
+    private OffsetDateTime joinDate;
 
     public PrayerGroupUserDTO(){}
 
-    public PrayerGroupUserDTO(int userId, String fullName, String username, String prayerGroupRole, Integer imageFileId, String fileName, String fileUrl, String fileType) {
+    public PrayerGroupUserDTO(int userId, String fullName, String username, String prayerGroupRole, Integer imageFileId, String fileName, String fileUrl, String fileType, OffsetDateTime joinDate) {
         this.userId = userId;
         this.fullName = fullName;
         this.username = username;
@@ -21,6 +24,7 @@ public class PrayerGroupUserDTO {
         this.fileName = fileName;
         this.fileUrl = fileUrl;
         this.fileType = fileType;
+        this.joinDate = joinDate;
     }
 
     public int getUserId() {
@@ -85,5 +89,13 @@ public class PrayerGroupUserDTO {
 
     public void setFileType(String fileType) {
         this.fileType = fileType;
+    }
+
+    public OffsetDateTime getJoinDate() {
+        return joinDate;
+    }
+
+    public void setJoinDate(OffsetDateTime joinDate) {
+        this.joinDate = joinDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/entities/PrayerGroupUser.java
+++ b/src/main/java/com/kevin/prayerappservice/group/entities/PrayerGroupUser.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.OffsetDateTime;
+
 @Entity
 public class PrayerGroupUser {
     @Id
@@ -26,12 +28,16 @@ public class PrayerGroupUser {
     @Enumerated(EnumType.STRING)
     private PrayerGroupRole prayerGroupRole;
 
+    @NotNull
+    private OffsetDateTime joinDate;
+
     public PrayerGroupUser(){}
 
-    public PrayerGroupUser(User user, PrayerGroup prayerGroup, PrayerGroupRole prayerGroupRole) {
+    public PrayerGroupUser(User user, PrayerGroup prayerGroup, PrayerGroupRole prayerGroupRole, OffsetDateTime joinDate) {
         this.user = user;
         this.prayerGroup = prayerGroup;
         this.prayerGroupRole = prayerGroupRole;
+        this.joinDate = joinDate;
     }
 
     public Integer getPrayerGroupUserId() {
@@ -64,5 +70,13 @@ public class PrayerGroupUser {
 
     public void setPrayerGroupRole(@NotNull PrayerGroupRole prayerGroupRole) {
         this.prayerGroupRole = prayerGroupRole;
+    }
+
+    public @NotNull OffsetDateTime getJoinDate() {
+        return joinDate;
+    }
+
+    public void setJoinDate(@NotNull OffsetDateTime joinDate) {
+        this.joinDate = joinDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/mappers/PrayerGroupMapper.java
+++ b/src/main/java/com/kevin/prayerappservice/group/mappers/PrayerGroupMapper.java
@@ -108,7 +108,7 @@ public interface PrayerGroupMapper {
 
         PrayerGroupUserModel[] prayerGroupUsers =
                 new PrayerGroupUserModel[]{new PrayerGroupUserModel(source.getAdminUserId(), null,
-                        null, source.getAdminFullName(), null, adminImage, PrayerGroupRole.ADMIN)};
+                        null, source.getAdminFullName(), null, adminImage, PrayerGroupRole.ADMIN, source.getAdminJoinDate())};
         return List.of(prayerGroupUsers);
     }
 

--- a/src/main/java/com/kevin/prayerappservice/group/models/CreatePrayerGroupRequest.java
+++ b/src/main/java/com/kevin/prayerappservice/group/models/CreatePrayerGroupRequest.java
@@ -1,22 +1,30 @@
 package com.kevin.prayerappservice.group.models;
 
 import com.kevin.prayerappservice.group.constants.VisibilityLevel;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.OffsetDateTime;
 
 public class CreatePrayerGroupRequest {
+    @NotNull
     private String groupName;
+
+    @NotNull
     private String description;
     private String rules;
     private Integer avatarFileId;
     private Integer bannerFileId;
     private VisibilityLevel visibilityLevel;
+    private OffsetDateTime createdDate;
 
-    public CreatePrayerGroupRequest(String groupName, String description, String rules, Integer avatarFileId, Integer bannerFileId, VisibilityLevel visibilityLevel) {
+    public CreatePrayerGroupRequest(String groupName, String description, String rules, Integer avatarFileId, Integer bannerFileId, VisibilityLevel visibilityLevel, OffsetDateTime createdDate) {
         this.groupName = groupName;
         this.description = description;
         this.rules = rules;
         this.avatarFileId = avatarFileId;
         this.bannerFileId = bannerFileId;
         this.visibilityLevel = visibilityLevel;
+        this.createdDate = createdDate;
     }
 
     public String getGroupName() {
@@ -65,5 +73,13 @@ public class CreatePrayerGroupRequest {
 
     public void setVisibilityLevel(VisibilityLevel visibilityLevel) {
         this.visibilityLevel = visibilityLevel;
+    }
+
+    public OffsetDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(OffsetDateTime createdDate) {
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupModel.java
+++ b/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupModel.java
@@ -7,6 +7,7 @@ import com.kevin.prayerappservice.group.constants.VisibilityLevel;
 import com.kevin.prayerappservice.group.entities.PrayerGroupUser;
 import com.kevin.prayerappservice.user.entities.User;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public class PrayerGroupModel {
@@ -21,10 +22,11 @@ public class PrayerGroupModel {
     private JoinStatus userJoinStatus;
     private PrayerGroupRole prayerGroupRole;
     private Integer joinRequestCount;
+    private OffsetDateTime userJoinDate;
 
     public PrayerGroupModel(){}
 
-    public PrayerGroupModel(Integer prayerGroupId, String groupName, String description, String rules, MediaFile avatarFile, MediaFile bannerFile, List<PrayerGroupUserModel> admins, VisibilityLevel visibilityLevel, JoinStatus userJoinStatus, PrayerGroupRole prayerGroupRole, Integer joinRequestCount) {
+    public PrayerGroupModel(Integer prayerGroupId, String groupName, String description, String rules, MediaFile avatarFile, MediaFile bannerFile, List<PrayerGroupUserModel> admins, VisibilityLevel visibilityLevel, JoinStatus userJoinStatus, PrayerGroupRole prayerGroupRole, Integer joinRequestCount, OffsetDateTime userJoinDate) {
         this.prayerGroupId = prayerGroupId;
         this.groupName = groupName;
         this.description = description;
@@ -36,6 +38,7 @@ public class PrayerGroupModel {
         this.userJoinStatus = userJoinStatus;
         this.prayerGroupRole = prayerGroupRole;
         this.joinRequestCount = joinRequestCount;
+        this.userJoinDate = userJoinDate;
     }
 
     public Integer getPrayerGroupId() {
@@ -124,5 +127,13 @@ public class PrayerGroupModel {
 
     public void setJoinRequestCount(Integer joinRequestCount) {
         this.joinRequestCount = joinRequestCount;
+    }
+
+    public OffsetDateTime getUserJoinDate() {
+        return userJoinDate;
+    }
+
+    public void setUserJoinDate(OffsetDateTime userJoinDate) {
+        this.userJoinDate = userJoinDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupSummaryModel.java
+++ b/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupSummaryModel.java
@@ -3,19 +3,23 @@ package com.kevin.prayerappservice.group.models;
 import com.kevin.prayerappservice.file.entities.MediaFile;
 import com.kevin.prayerappservice.group.constants.JoinStatus;
 
+import java.time.OffsetDateTime;
+
 public class PrayerGroupSummaryModel {
     private int prayerGroupId;
     private String groupName;
     private MediaFile avatarFile;
     private JoinStatus joinStatus;
+    private OffsetDateTime addedDate;
 
     public PrayerGroupSummaryModel(){}
 
-    public PrayerGroupSummaryModel(int prayerGroupId, String groupName, MediaFile avatarFile, JoinStatus joinStatus) {
+    public PrayerGroupSummaryModel(int prayerGroupId, String groupName, MediaFile avatarFile, JoinStatus joinStatus, OffsetDateTime addedDate) {
         this.prayerGroupId = prayerGroupId;
         this.groupName = groupName;
         this.avatarFile = avatarFile;
         this.joinStatus = joinStatus;
+        this.addedDate = addedDate;
     }
 
     public int getPrayerGroupId() {
@@ -48,5 +52,13 @@ public class PrayerGroupSummaryModel {
 
     public void setJoinStatus(JoinStatus joinStatus) {
         this.joinStatus = joinStatus;
+    }
+
+    public OffsetDateTime getAddedDate() {
+        return addedDate;
+    }
+
+    public void setAddedDate(OffsetDateTime addedDate) {
+        this.addedDate = addedDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupUserCreateRequest.java
+++ b/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupUserCreateRequest.java
@@ -1,0 +1,21 @@
+package com.kevin.prayerappservice.group.models;
+
+import java.time.OffsetDateTime;
+
+public class PrayerGroupUserCreateRequest {
+    private OffsetDateTime joinDate;
+
+    public PrayerGroupUserCreateRequest(){}
+
+    public PrayerGroupUserCreateRequest(OffsetDateTime joinDate) {
+        this.joinDate = joinDate;
+    }
+
+    public OffsetDateTime getJoinDate() {
+        return joinDate;
+    }
+
+    public void setJoinDate(OffsetDateTime joinDate) {
+        this.joinDate = joinDate;
+    }
+}

--- a/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupUserModel.java
+++ b/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupUserModel.java
@@ -6,16 +6,20 @@ import com.kevin.prayerappservice.group.constants.PrayerGroupRole;
 import com.kevin.prayerappservice.user.models.UserSummary;
 import com.kevin.prayerappservice.user.models.UserTokenPair;
 
+import java.time.OffsetDateTime;
+
 public class PrayerGroupUserModel extends UserSummary {
     private PrayerGroupRole prayerGroupRole;
+    private OffsetDateTime joinDate;
 
     public PrayerGroupUserModel() {
         super();
     }
 
-    public PrayerGroupUserModel(int userId, String username, String emailAddress, String fullName, UserTokenPair tokens, MediaFileSummary image, PrayerGroupRole prayerGroupRole) {
+    public PrayerGroupUserModel(int userId, String username, String emailAddress, String fullName, UserTokenPair tokens, MediaFileSummary image, PrayerGroupRole prayerGroupRole, OffsetDateTime joinDate) {
         super(userId, username, emailAddress, fullName, tokens, image, null);
         this.prayerGroupRole = prayerGroupRole;
+        this.joinDate = joinDate;
     }
 
     public PrayerGroupRole getPrayerGroupRole() {
@@ -24,5 +28,13 @@ public class PrayerGroupUserModel extends UserSummary {
 
     public void setPrayerGroupRole(PrayerGroupRole prayerGroupRole) {
         this.prayerGroupRole = prayerGroupRole;
+    }
+
+    public OffsetDateTime getJoinDate() {
+        return joinDate;
+    }
+
+    public void setJoinDate(OffsetDateTime joinDate) {
+        this.joinDate = joinDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupUserUpdateRequest.java
+++ b/src/main/java/com/kevin/prayerappservice/group/models/PrayerGroupUserUpdateRequest.java
@@ -2,15 +2,17 @@ package com.kevin.prayerappservice.group.models;
 
 import jakarta.validation.constraints.NotNull;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public class PrayerGroupUserUpdateRequest {
     @NotNull
     private List<PrayerGroupUserUpdateModel> prayerGroupUsers;
+    private OffsetDateTime updateDate;
 
     public PrayerGroupUserUpdateRequest(){}
 
-    public PrayerGroupUserUpdateRequest(List<PrayerGroupUserUpdateModel> prayerGroupUsers) {
+    public PrayerGroupUserUpdateRequest(List<PrayerGroupUserUpdateModel> prayerGroupUsers, OffsetDateTime updateDate) {
         this.prayerGroupUsers = prayerGroupUsers;
     }
 
@@ -20,5 +22,13 @@ public class PrayerGroupUserUpdateRequest {
 
     public void setPrayerGroupUsers(List<PrayerGroupUserUpdateModel> prayerGroupUsers) {
         this.prayerGroupUsers = prayerGroupUsers;
+    }
+
+    public OffsetDateTime getUpdateDate() {
+        return updateDate;
+    }
+
+    public void setUpdateDate(OffsetDateTime updateDate) {
+        this.updateDate = updateDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/join/JoinRequestJdbcRepository.java
+++ b/src/main/java/com/kevin/prayerappservice/join/JoinRequestJdbcRepository.java
@@ -2,10 +2,11 @@ package com.kevin.prayerappservice.join;
 
 import com.kevin.prayerappservice.join.dtos.JoinRequestDTO;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface JoinRequestJdbcRepository {
     List<JoinRequestDTO> getJoinRequests(int prayerGroupId);
     void deleteJoinRequests(int prayerGroupId, List<Integer> joinRequestIds);
-    void approveJoinRequests(int prayerGroupId, List<Integer> joinRequestIds);
+    void approveJoinRequests(int prayerGroupId, List<Integer> joinRequestIds, OffsetDateTime approveDate);
 }

--- a/src/main/java/com/kevin/prayerappservice/join/JoinRequestJdbcRepositoryImpl.java
+++ b/src/main/java/com/kevin/prayerappservice/join/JoinRequestJdbcRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Repository
@@ -34,10 +35,10 @@ public class JoinRequestJdbcRepositoryImpl implements JoinRequestJdbcRepository 
         jdbcTemplate.update(sql, params);
     }
 
-    public void approveJoinRequests(int prayerGroupId, List<Integer> joinRequestIds){
-        String sql = "CALL approve_join_requests(:targetPrayerGroupId, :joinRequestIds);";
+    public void approveJoinRequests(int prayerGroupId, List<Integer> joinRequestIds, OffsetDateTime approveDate){
+        String sql = "CALL approve_join_requests(:targetPrayerGroupId, :joinRequestIds, :approveDate);";
         int[] joinRequestIdsArr = joinRequestIds.stream().mapToInt(Integer::intValue).toArray();
-        JoinRequestApproveQuery joinRequestApproveQuery = new JoinRequestApproveQuery(prayerGroupId, joinRequestIdsArr);
+        JoinRequestApproveQuery joinRequestApproveQuery = new JoinRequestApproveQuery(prayerGroupId, joinRequestIdsArr, approveDate);
         BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(joinRequestApproveQuery);
         jdbcTemplate.update(sql, params);
     }

--- a/src/main/java/com/kevin/prayerappservice/join/JoinRequestService.java
+++ b/src/main/java/com/kevin/prayerappservice/join/JoinRequestService.java
@@ -22,6 +22,7 @@ import com.kevin.prayerappservice.user.models.UserSummary;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Service;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -93,7 +94,9 @@ public class JoinRequestService {
             throw new DataValidationException(JoinRequestErrorMessages.NON_ADMIN_CANNOT_DELETE_JOIN_REQUEST);
         }
 
-        joinRequestRepository.approveJoinRequests(prayerGroupId, approveRequest.getJoinRequestIds());
+        OffsetDateTime approveDate = Optional.ofNullable(approveRequest.getApproveDate()).orElse(OffsetDateTime.now());
+
+        joinRequestRepository.approveJoinRequests(prayerGroupId, approveRequest.getJoinRequestIds(), approveDate);
     }
 
 

--- a/src/main/java/com/kevin/prayerappservice/join/dtos/JoinRequestApproveQuery.java
+++ b/src/main/java/com/kevin/prayerappservice/join/dtos/JoinRequestApproveQuery.java
@@ -1,14 +1,18 @@
 package com.kevin.prayerappservice.join.dtos;
 
+import java.time.OffsetDateTime;
+
 public class JoinRequestApproveQuery {
     private int targetPrayerGroupId;
     private int[] joinRequestIds;
+    private OffsetDateTime approveDate;
 
     public JoinRequestApproveQuery(){}
 
-    public JoinRequestApproveQuery(int targetPrayerGroupId, int[] joinRequestIds) {
+    public JoinRequestApproveQuery(int targetPrayerGroupId, int[] joinRequestIds, OffsetDateTime approveDate) {
         this.targetPrayerGroupId = targetPrayerGroupId;
         this.joinRequestIds = joinRequestIds;
+        this.approveDate = approveDate;
     }
 
     public int getTargetPrayerGroupId() {
@@ -25,5 +29,13 @@ public class JoinRequestApproveQuery {
 
     public void setJoinRequestIds(int[] joinRequestIds) {
         this.joinRequestIds = joinRequestIds;
+    }
+
+    public OffsetDateTime getApproveDate() {
+        return approveDate;
+    }
+
+    public void setApproveDate(OffsetDateTime approveDate) {
+        this.approveDate = approveDate;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/join/models/JoinRequestApproveRequest.java
+++ b/src/main/java/com/kevin/prayerappservice/join/models/JoinRequestApproveRequest.java
@@ -1,14 +1,17 @@
 package com.kevin.prayerappservice.join.models;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public class JoinRequestApproveRequest {
     private List<Integer> joinRequestIds;
+    private OffsetDateTime approveDate;
 
     public JoinRequestApproveRequest(){}
 
-    public JoinRequestApproveRequest(List<Integer> joinRequestIds) {
+    public JoinRequestApproveRequest(List<Integer> joinRequestIds, OffsetDateTime approveDate) {
         this.joinRequestIds = joinRequestIds;
+        this.approveDate = approveDate;
     }
 
     public List<Integer> getJoinRequestIds() {
@@ -17,5 +20,13 @@ public class JoinRequestApproveRequest {
 
     public void setJoinRequestIds(List<Integer> joinRequestIds) {
         this.joinRequestIds = joinRequestIds;
+    }
+
+    public OffsetDateTime getApproveDate() {
+        return approveDate;
+    }
+
+    public void setApproveDate(OffsetDateTime approveDate) {
+        this.approveDate = approveDate;
     }
 }

--- a/src/main/resources/db/migration/V2_51__add_join_date.sql
+++ b/src/main/resources/db/migration/V2_51__add_join_date.sql
@@ -1,0 +1,9 @@
+ALTER TABLE prayer_group_user
+ADD COLUMN join_date TIMESTAMPTZ;
+
+UPDATE prayer_group_user
+SET join_date = now()
+WHERE join_date IS NULL;
+
+ALTER TABLE prayer_group_user
+ALTER COLUMN join_date SET NOT NULL;

--- a/src/main/resources/db/migration/V2_52__create_prayer_group_join_date.sql
+++ b/src/main/resources/db/migration/V2_52__create_prayer_group_join_date.sql
@@ -1,0 +1,143 @@
+DROP FUNCTION IF EXISTS create_prayer_group;
+
+CREATE OR REPLACE FUNCTION create_prayer_group(
+    creator_user_id INT,
+    new_group_name VARCHAR(255),
+    group_description TEXT,
+    group_rules TEXT,
+    group_visibility VARCHAR(255),
+    group_avatar_file_id INT,
+    group_banner_file_id INT,
+    created_date TIMESTAMPTZ
+) RETURNS TABLE (
+    prayer_group_id INT,
+    group_name VARCHAR(255),
+    description TEXT,
+    rules TEXT,
+    visibility_level VARCHAR(255),
+    avatar_file_id INT,
+    group_avatar_file_name VARCHAR(255),
+    group_avatar_file_url VARCHAR(255),
+    banner_file_id INT,
+    group_banner_file_name VARCHAR(255),
+    group_banner_file_url VARCHAR(255),
+    admin_user_id INT,
+    admin_full_name VARCHAR(255),
+    admin_image_file_id INT,
+    admin_image_file_name VARCHAR(255),
+    admin_image_file_url VARCHAR(255),
+    admin_join_date TIMESTAMPTZ
+)
+AS
+$$
+DECLARE
+        new_group_id INT;
+BEGIN
+    DROP TABLE IF EXISTS temp_admin_user;
+    DROP TABLE IF EXISTS temp_relevant_files;
+
+    CREATE TEMPORARY TABLE temp_admin_user (
+        user_id INT,
+        full_name VARCHAR(255),
+        image_file_id INT
+    );
+
+    CREATE TEMPORARY TABLE temp_relevant_files (
+        media_file_id INT,
+        file_name VARCHAR(255),
+        file_url VARCHAR(255),
+        file_type VARCHAR(255)
+    );
+
+    INSERT INTO
+        temp_admin_user (user_id, full_name, image_file_id)
+    SELECT
+        u.user_id,
+        full_name,
+        u.image_file_id
+    FROM
+        app_user u
+    WHERE u.user_id = creator_user_id;
+
+    INSERT INTO
+        temp_relevant_files (media_file_id, file_name, file_url, file_type)
+    SELECT
+        f.media_file_id,
+        f.file_name,
+        f.file_url,
+        f.file_type
+    FROM media_file f, temp_admin_user a
+    WHERE f.media_file_id IN (a.image_file_id, group_avatar_file_id, group_banner_file_id);
+
+    IF NOT EXISTS (SELECT 1 FROM temp_admin_user)
+    THEN
+        RAISE EXCEPTION 'User does not exist.';
+    END IF;
+
+    IF group_avatar_file_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM temp_relevant_files f
+        WHERE f.media_file_id = group_avatar_file_id AND file_type = 'IMAGE'
+    )
+    THEN
+        RAISE EXCEPTION 'Avatar image for group not found or file is not an image.';
+    END IF;
+
+    IF group_banner_file_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM temp_relevant_files f
+        WHERE f.media_file_id = group_banner_file_id AND file_type = 'IMAGE'
+    )
+    THEN
+        RAISE EXCEPTION 'Banner image for group not found or file is not an image.';
+    END IF;
+
+
+    INSERT INTO
+        prayer_group (group_name, description, rules, visibility_level, avatar_file_id, banner_file_id)
+    VALUES
+        (new_group_name, group_description, group_rules, group_visibility, group_avatar_file_id, group_banner_file_id)
+    RETURNING prayer_group.prayer_group_id INTO new_group_id;
+
+    INSERT INTO
+        prayer_group_user (prayer_group_id, user_id, prayer_group_role, join_date)
+    SELECT
+        new_group_id,
+        a.user_id,
+        'ADMIN',
+        created_date
+    FROM
+        temp_admin_user a;
+
+    RETURN QUERY
+        SELECT
+            new_group_id,
+            new_group_name,
+            group_description,
+            group_rules,
+            group_visibility,
+            group_avatar_file_id,
+            f2.file_name,
+            f2.file_url,
+            group_banner_file_id,
+            f3.file_name,
+            f3.file_url,
+            a.user_id,
+            a.full_name,
+            a.image_file_id,
+            f1.file_name,
+            f1.file_url,
+            created_date
+        FROM temp_admin_user a
+        LEFT JOIN temp_relevant_files f1 ON a.image_file_id = f1.media_file_id
+        LEFT JOIN temp_relevant_files f2 ON f2.media_file_id = group_avatar_file_id
+        LEFT JOIN temp_relevant_files f3 ON f3.media_file_id = group_banner_file_id;
+    DROP TABLE IF EXISTS temp_admin_user;
+    DROP TABLE IF EXISTS temp_relevant_files;
+    RETURN;
+EXCEPTION
+    WHEN OTHERS THEN
+        DROP TABLE IF EXISTS temp_admin_user;
+        DROP TABLE IF EXISTS temp_relevant_files;
+        RAISE;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_53__get_prayer_group_join_date.sql
+++ b/src/main/resources/db/migration/V2_53__get_prayer_group_join_date.sql
@@ -1,0 +1,71 @@
+DROP FUNCTION IF EXISTS get_prayer_group;
+
+CREATE OR REPLACE FUNCTION get_prayer_group(
+    target_prayer_group_id INT,
+    target_user_id INT
+) RETURNS TABLE (
+    prayer_group_id INT,
+    group_name VARCHAR(255),
+    description TEXT,
+    rules TEXT,
+    visibility_level VARCHAR(255),
+    avatar_file_id INT,
+    avatar_file_name VARCHAR(255),
+    avatar_file_url VARCHAR(255),
+    avatar_file_type VARCHAR(255),
+    banner_file_id INT,
+    banner_file_name VARCHAR(255),
+    banner_file_url VARCHAR(255),
+    banner_file_type VARCHAR(255),
+    prayer_group_role VARCHAR(255),
+    join_request_id INT,
+    join_request_count INT,
+    user_join_date TIMESTAMPTZ
+)
+AS
+$$
+DECLARE
+    join_request_count INT;
+BEGIN
+    SELECT
+        COUNT(*)
+    INTO
+        join_request_count
+    FROM
+        join_request r1
+    WHERE r1.prayer_group_id = target_prayer_group_id;
+
+    RETURN QUERY
+        SELECT
+            g.prayer_group_id,
+            g.group_name,
+            g.description,
+            g.rules,
+            g.visibility_level,
+            g.avatar_file_id,
+            f1.file_name AS avatar_file_name,
+            f1.file_url AS avatar_file_url,
+            f1.file_type AS avatar_file_type,
+            g.banner_file_id,
+            f2.file_name AS banner_file_name,
+            f2.file_url AS banner_file_url,
+            f2.file_type AS banner_file_type,
+            pgu.prayer_group_role,
+            r2.join_request_id,
+            join_request_count,
+            pgu.join_date AS user_join_date
+        FROM
+            prayer_group g
+        LEFT JOIN
+            media_file f1 ON f1.media_file_id = g.avatar_file_id
+        LEFT JOIN
+            media_file f2 ON f2.media_file_id = g.banner_file_id
+        LEFT JOIN
+            prayer_group_user pgu ON pgu.prayer_group_id = g.prayer_group_id AND pgu.user_id = target_user_id
+        LEFT JOIN
+            join_request r2 ON r2.prayer_group_id = g.prayer_group_id AND r2.user_id = target_user_id
+        WHERE
+            g.prayer_group_id = target_prayer_group_id;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_54__get_prayer_group_users_join_date.sql
+++ b/src/main/resources/db/migration/V2_54__get_prayer_group_users_join_date.sql
@@ -1,0 +1,40 @@
+DROP FUNCTION IF EXISTS get_prayer_group_users;
+
+CREATE OR REPLACE FUNCTION get_prayer_group_users(group_id INT, prayer_group_roles VARCHAR(255)[] DEFAULT NULL)
+RETURNS TABLE (
+    user_id INT,
+    full_name VARCHAR(255),
+    username VARCHAR(255),
+    prayer_group_role VARCHAR(255),
+    image_file_id INT,
+    file_name VARCHAR(255),
+    file_url VARCHAR(255),
+    file_type VARCHAR(255),
+    join_date TIMESTAMPTZ
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+    SELECT
+        a.user_id,
+        a.full_name,
+        a.username,
+        g.prayer_group_role,
+        a.image_file_id,
+        f.file_name,
+        f.file_url,
+        f.file_type,
+        g.join_date
+    FROM
+        prayer_group_user g
+    INNER JOIN
+        app_user a ON g.user_id = a.user_id
+    LEFT JOIN
+        media_file f ON f.media_file_id = a.image_file_id
+    WHERE
+        prayer_group_id = group_id AND (prayer_group_roles IS NULL OR g.prayer_group_role = ANY(prayer_group_roles));
+    RETURN;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_55__get_prayer_group_summaries_by_user_join_date.sql
+++ b/src/main/resources/db/migration/V2_55__get_prayer_group_summaries_by_user_join_date.sql
@@ -1,0 +1,57 @@
+DROP FUNCTION IF EXISTS get_prayer_group_summaries_by_user;
+
+CREATE OR REPLACE FUNCTION get_prayer_group_summaries_by_user(
+    p_user_id INT
+) RETURNS TABLE (
+    prayer_group_id INT,
+    group_name VARCHAR(255),
+    media_file_id INT,
+    file_name VARCHAR(255),
+    file_url VARCHAR(255),
+    file_type VARCHAR(255),
+    join_status VARCHAR(255),
+    added_date TIMESTAMPTZ
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+        (
+            SELECT
+                g.prayer_group_id,
+                g.group_name,
+                f.media_file_id,
+                f.file_name,
+                f.file_url,
+                f.file_type,
+                'JOINED'::VARCHAR(255) AS join_status,
+                u.join_date AS added_date
+            FROM
+                prayer_group_user u
+            INNER JOIN
+                prayer_group g ON g.prayer_group_id = u.prayer_group_id
+            LEFT JOIN
+                media_file f ON f.media_file_id = g.avatar_file_id
+            WHERE user_id = p_user_id
+        )
+        UNION (
+            SELECT
+                g.prayer_group_id,
+                g.group_name,
+                f.media_file_id,
+                f.file_name,
+                f.file_url,
+                f.file_type,
+                'REQUEST_SUBMITTED'::VARCHAR(255) AS join_status,
+                j.submitted_date AS added_date
+            FROM
+                join_request j
+            INNER JOIN
+                prayer_group g ON g.prayer_group_id = j.prayer_group_id
+            LEFT JOIN
+                media_file f ON f.media_file_id = g.avatar_file_id
+            WHERE user_id = p_user_id
+        );
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_56__update_prayer_group_users_join_date.sql
+++ b/src/main/resources/db/migration/V2_56__update_prayer_group_users_join_date.sql
@@ -1,0 +1,46 @@
+DROP PROCEDURE IF EXISTS update_prayer_group_users;
+
+CREATE OR REPLACE PROCEDURE update_prayer_group_users (p_prayer_group_id INT, p_updated_users prayer_group_user_update_item[], p_update_date TIMESTAMPTZ)
+AS $$
+BEGIN
+    DROP TABLE IF EXISTS prayer_group_update_items;
+
+    CREATE TEMPORARY TABLE prayer_group_update_items (
+        user_id INT,
+        prayer_group_role VARCHAR(255)
+    );
+
+    INSERT INTO
+        prayer_group_update_items (user_id, prayer_group_role)
+    SELECT
+        (u).user_id, (u).prayer_group_role
+    FROM unnest(p_updated_users) AS u;
+
+    DELETE FROM
+        prayer_group_user pgu
+    WHERE pgu.prayer_group_id = p_prayer_group_id AND pgu.user_id NOT IN (
+        SELECT
+            pgui.user_id
+        FROM
+            prayer_group_update_items pgui
+    );
+
+    MERGE INTO
+        prayer_group_user AS pgu
+    USING
+        prayer_group_update_items AS pgui
+    ON
+        pgu.prayer_group_id = p_prayer_group_id AND pgu.user_id = pgui.user_id
+    WHEN MATCHED THEN
+        UPDATE SET prayer_group_role = pgui.prayer_group_role
+    WHEN NOT MATCHED THEN
+        INSERT (user_id, prayer_group_id, prayer_group_role, join_date) VALUES (pgui.user_id, p_prayer_group_id, pgui.prayer_group_role, p_update_date);
+
+    EXCEPTION
+        WHEN OTHERS THEN
+            DROP TABLE IF EXISTS prayer_group_update_items;
+            RAISE;
+
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_57__approve_join_requests_join_date.sql
+++ b/src/main/resources/db/migration/V2_57__approve_join_requests_join_date.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE PROCEDURE approve_join_requests(target_prayer_group_id INT, join_request_ids INT[], approve_date TIMESTAMPTZ)
+AS
+$$
+BEGIN
+    INSERT INTO
+        prayer_group_user (user_id, prayer_group_id, prayer_group_role, join_date)
+    SELECT
+        user_id,
+        prayer_group_id,
+        'MEMBER',
+        approve_date
+    FROM
+        join_request j
+    WHERE
+        j.prayer_group_id = target_prayer_group_id AND j.join_request_id = ANY(join_request_ids);
+
+    DELETE FROM
+        join_request j
+    WHERE
+        j.prayer_group_id = target_prayer_group_id AND j.join_request_id = ANY(join_request_ids);
+
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/test/java/com/kevin/prayerappservice/service/JoinRequestServiceTests.java
+++ b/src/test/java/com/kevin/prayerappservice/service/JoinRequestServiceTests.java
@@ -79,7 +79,7 @@ public class JoinRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Indiana State Government", "State government prayer group", "Rules", VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
         prayerGroupUserRepository.save(mockPrayerGroupUser);
 
         JoinRequestCreateRequest createRequest = new JoinRequestCreateRequest(user.getUserId(), OffsetDateTime.now());
@@ -173,7 +173,7 @@ public class JoinRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Pawnee Prayer Group", "Pawnee prayer group", "Prayer group rules", VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
         Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
@@ -202,7 +202,7 @@ public class JoinRequestServiceTests {
         Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(jwtService.extractUserId("mockToken")).thenReturn(user.getUserId());
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
         JoinRequestDeleteRequest joinRequestDeleteRequest = new JoinRequestDeleteRequest(joinRequestIdsToDelete);
@@ -231,10 +231,10 @@ public class JoinRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Pawnee Today Prayer Group", "A prayer group for Pawnee's favorite talk show Pawnee Today", "Pawnee Today rules", VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
-        JoinRequestApproveRequest request = new JoinRequestApproveRequest(List.of(717, 727, 737));
+        JoinRequestApproveRequest request = new JoinRequestApproveRequest(List.of(717, 727, 737), OffsetDateTime.now());
 
         Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(jwtService.extractUserId("mockToken")).thenReturn(user.getUserId());
@@ -252,21 +252,22 @@ public class JoinRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Pawnee Today Prayer Group", "A prayer group for Pawnee's favorite talk show Pawnee Today", "Pawnee Today rules", VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
         Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(jwtService.extractUserId("mockToken")).thenReturn(user.getUserId());
 
-        Mockito.doNothing().when(mockJoinRequestJdbcRepository).approveJoinRequests(anyInt(), Mockito.anyList());
+        Mockito.doNothing().when(mockJoinRequestJdbcRepository).approveJoinRequests(anyInt(), Mockito.anyList(), Mockito.any());
 
         ArgumentCaptor<Integer> targetPrayerGroupCaptor = ArgumentCaptor.forClass(Integer.class);
         ArgumentCaptor<List<Integer>> targetJoinRequestIds = ArgumentCaptor.forClass((Class) List.class);
+        ArgumentCaptor<OffsetDateTime> targetApproveDate = ArgumentCaptor.forClass(OffsetDateTime.class);
 
-        JoinRequestApproveRequest request = new JoinRequestApproveRequest(List.of(717, 727, 737));
+        JoinRequestApproveRequest request = new JoinRequestApproveRequest(List.of(717, 727, 737), OffsetDateTime.now());
         joinRequestService.approveJoinRequests("mockToken", prayerGroup.getPrayerGroupId(), request);
 
-        Mockito.verify(mockJoinRequestJdbcRepository).approveJoinRequests(targetPrayerGroupCaptor.capture(), targetJoinRequestIds.capture());
+        Mockito.verify(mockJoinRequestJdbcRepository).approveJoinRequests(targetPrayerGroupCaptor.capture(), targetJoinRequestIds.capture(), targetApproveDate.capture());
 
         Assertions.assertThat(targetPrayerGroupCaptor.getValue()).isEqualTo(prayerGroup.getPrayerGroupId());
         Assertions.assertThat(targetJoinRequestIds.getValue()).isEqualTo(request.getJoinRequestIds());

--- a/src/test/java/com/kevin/prayerappservice/service/PrayerGroupServiceTests.java
+++ b/src/test/java/com/kevin/prayerappservice/service/PrayerGroupServiceTests.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.parameters.P;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -99,12 +100,12 @@ public class PrayerGroupServiceTests {
         CreatedPrayerGroupDTO createdPrayerGroupDTO = new CreatedPrayerGroupDTO(737, "河北大学", "河北大学学生小组", null,
                 VisibilityLevel.PRIVATE, 757, "hebeidaxue.png", "https://prayerappfileservices.pythonanywhere" +
                 ".com/static/test.png", 767, "hebeidaxue_zhaopian.png", "https://prayerappfileservices.pythonanywhere" +
-                ".static/test.png", 80, "王明", null, null, null);
+                ".static/test.png", 80, "王明", null, null, null, OffsetDateTime.now());
 
         CreatePrayerGroupRequest request = new CreatePrayerGroupRequest(createdPrayerGroupDTO.getGroupName(),
                 createdPrayerGroupDTO.getDescription(), createdPrayerGroupDTO.getRules(),
                 createdPrayerGroupDTO.getAvatarFileId(), createdPrayerGroupDTO.getBannerFileId(),
-                createdPrayerGroupDTO.getVisibilityLevel());
+                createdPrayerGroupDTO.getVisibilityLevel(), OffsetDateTime.now());
 
         Mockito.when(mockPrayerGroupJdbcRepository.createPrayerGroup(any(CreatePrayerGroupRequestDTO.class))).thenReturn(createdPrayerGroupDTO);
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(createdPrayerGroupDTO.getAdminUserId());
@@ -119,12 +120,12 @@ public class PrayerGroupServiceTests {
     @Test
     public void createPrayerGroup_givenPrayerGroupWithNullableFields_returnsGroupModel() {
         CreatedPrayerGroupDTO createdPrayerGroupDTO = new CreatedPrayerGroupDTO(777, "Top Gear", null, null,
-                VisibilityLevel.PUBLIC, null, null, null, null, null, null, 80, "James May", null, null, null);
+                VisibilityLevel.PUBLIC, null, null, null, null, null, null, 80, "James May", null, null, null, OffsetDateTime.now());
 
         CreatePrayerGroupRequest request = new CreatePrayerGroupRequest(createdPrayerGroupDTO.getGroupName(),
                 createdPrayerGroupDTO.getDescription(), createdPrayerGroupDTO.getRules(),
                 createdPrayerGroupDTO.getAvatarFileId(), createdPrayerGroupDTO.getBannerFileId(),
-                createdPrayerGroupDTO.getVisibilityLevel());
+                createdPrayerGroupDTO.getVisibilityLevel(), OffsetDateTime.now());
 
         Mockito.when(mockPrayerGroupJdbcRepository.createPrayerGroup(any(CreatePrayerGroupRequestDTO.class))).thenReturn(createdPrayerGroupDTO);
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(createdPrayerGroupDTO.getAdminUserId());
@@ -141,7 +142,7 @@ public class PrayerGroupServiceTests {
         PrayerGroupDTO mockPrayerGroup = new PrayerGroupDTO(6116, "Naboo Delegation", "Senator Amidala and " +
                 "Representative Binks", null, VisibilityLevel.PRIVATE.toString(), 34, "naboo.png", "https" +
                 "://prayerappfileservices.pythonanywhere.com/test.png", FileType.IMAGE.toString(), null, null, null,
-                null, PrayerGroupRole.MEMBER.toString(), null, null);
+                null, PrayerGroupRole.MEMBER.toString(), null, null, OffsetDateTime.now());
 
         Mockito.when(mockPrayerGroupJdbcRepository.getPrayerGroup(anyInt(), anyInt())).thenReturn(mockPrayerGroup);
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(1409);
@@ -158,7 +159,7 @@ public class PrayerGroupServiceTests {
         PrayerGroupDTO mockPrayerGroup = new PrayerGroupDTO(6116, "Naboo Delegation", "Senator Amidala and " +
                 "Representative Binks", null, VisibilityLevel.PRIVATE.toString(), 34, "naboo.png", "https" +
                 "://prayerappfileservices.pythonanywhere.com/test.png", FileType.IMAGE.toString(), null, null, null,
-                null, null, 1004, null);
+                null, null, 1004, null, OffsetDateTime.now());
 
         Mockito.when(mockPrayerGroupJdbcRepository.getPrayerGroup(anyInt(), anyInt())).thenReturn(mockPrayerGroup);
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(1409);
@@ -173,7 +174,7 @@ public class PrayerGroupServiceTests {
         PrayerGroupDTO mockPrayerGroup = new PrayerGroupDTO(6116, "Naboo Delegation", "Senator Amidala and " +
                 "Representative Binks", null, VisibilityLevel.PRIVATE.toString(), 34, "naboo.png", "https" +
                 "://prayerappfileservices.pythonanywhere.com/test.png", FileType.IMAGE.toString(), null, null, null,
-                null, null, 1004, null);
+                null, null, 1004, null, OffsetDateTime.now());
 
         PrayerGroupUserDTO[] prayerGroupUserDTOS = new PrayerGroupUserDTO[]{
                 new PrayerGroupUserDTO(320, "Padme Amidala", "pamidala", PrayerGroupRole.ADMIN.toString(), null, null
@@ -208,7 +209,7 @@ public class PrayerGroupServiceTests {
         Mockito.when(mockJwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(mockUser.getUserId());
 
-        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(mockUser, mockPrayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(mockUser, mockPrayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
         prayerGroupUserRepository.save(mockPrayerGroupUser);
 
 
@@ -233,7 +234,7 @@ public class PrayerGroupServiceTests {
         Mockito.when(mockJwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(mockUser.getUserId());
 
-        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(mockUser, mockPrayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(mockUser, mockPrayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
         prayerGroupUserRepository.save(mockPrayerGroupUser);
 
         JoinRequest joinRequest = new JoinRequest(mockUser, mockPrayerGroup, OffsetDateTime.now());
@@ -260,7 +261,7 @@ public class PrayerGroupServiceTests {
         Mockito.when(mockJwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(mockUser.getUserId());
 
-        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(mockUser, mockPrayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser mockPrayerGroupUser = new PrayerGroupUser(mockUser, mockPrayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
         prayerGroupUserRepository.save(mockPrayerGroupUser);
 
         PutPrayerGroupRequest putPrayerGroupRequest = new PutPrayerGroupRequest("Alphabet", "Parent company of " +
@@ -298,8 +299,10 @@ public class PrayerGroupServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Parks and Recreation Department", "Pawnee Parks and Recreation department", null, VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
+        PrayerGroupUserCreateRequest createRequest = new PrayerGroupUserCreateRequest(OffsetDateTime.now());
+
         Assertions.assertThatExceptionOfType(DataValidationException.class)
-                .isThrownBy(() -> prayerGroupService.addPrayerGroupUser("mockToken", prayerGroup.getPrayerGroupId(), 2));
+                .isThrownBy(() -> prayerGroupService.addPrayerGroupUser("mockToken", prayerGroup.getPrayerGroupId(), 2, createRequest));
     }
 
     @Test
@@ -311,14 +314,14 @@ public class PrayerGroupServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Parks and Recreation Department", "Pawnee Parks and Recreation department", null, VisibilityLevel.PUBLIC, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
         Mockito.when(mockJwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(user.getUserId());
 
         Assertions.assertThatExceptionOfType(DataValidationException.class)
-                .isThrownBy(() -> prayerGroupService.addPrayerGroupUser("mockToken", prayerGroup.getPrayerGroupId(), user.getUserId() + 1));
+                .isThrownBy(() -> prayerGroupService.addPrayerGroupUser("mockToken", prayerGroup.getPrayerGroupId(), user.getUserId() + 1, new PrayerGroupUserCreateRequest(OffsetDateTime.now())));
     }
 
     @Test
@@ -334,7 +337,9 @@ public class PrayerGroupServiceTests {
         Mockito.when(mockJwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(mockJwtService.extractUserId(anyString())).thenReturn(user.getUserId());
 
-        PrayerGroupUserModel addedUser = prayerGroupService.addPrayerGroupUser("Bearer mockToken", prayerGroup.getPrayerGroupId(), user.getUserId());
+
+
+        PrayerGroupUserModel addedUser = prayerGroupService.addPrayerGroupUser("Bearer mockToken", prayerGroup.getPrayerGroupId(), user.getUserId(), new PrayerGroupUserCreateRequest(OffsetDateTime.now()));
 
         Assertions.assertThat(addedUser.getUserId()).isEqualTo(user.getUserId());
         Assertions.assertThat(addedUser.getPrayerGroupRole()).isEqualTo(PrayerGroupRole.MEMBER);
@@ -350,7 +355,7 @@ public class PrayerGroupServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Parks and Recreation Department", "Pawnee Parks and Recreation department", null, VisibilityLevel.PUBLIC, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, prayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
         Mockito.when(mockJwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
@@ -359,7 +364,7 @@ public class PrayerGroupServiceTests {
         User user2 = new User("Tom Haverford", "thaverford", "thaverford@parksandrec.gov", "mockPassword", Role.USER);
         userRepository.save(user2);
 
-        PrayerGroupUserModel prayerGroupUserModel = prayerGroupService.addPrayerGroupUser("mockToken", 1, user2.getUserId());
+        PrayerGroupUserModel prayerGroupUserModel = prayerGroupService.addPrayerGroupUser("mockToken", 1, user2.getUserId(), new PrayerGroupUserCreateRequest(OffsetDateTime.now()));
 
         Assertions.assertThat(prayerGroupUserModel.getUserId()).isEqualTo(user2.getUserId());
         Assertions.assertThat(prayerGroupUserModel.getPrayerGroupRole()).isEqualTo(PrayerGroupRole.MEMBER);

--- a/src/test/java/com/kevin/prayerappservice/service/PrayerGroupServiceTests.java
+++ b/src/test/java/com/kevin/prayerappservice/service/PrayerGroupServiceTests.java
@@ -178,10 +178,10 @@ public class PrayerGroupServiceTests {
 
         PrayerGroupUserDTO[] prayerGroupUserDTOS = new PrayerGroupUserDTO[]{
                 new PrayerGroupUserDTO(320, "Padme Amidala", "pamidala", PrayerGroupRole.ADMIN.toString(), null, null
-                        , null, null),
+                        , null, null, OffsetDateTime.now()),
                 new PrayerGroupUserDTO(380, "Jar Jar Binks", "jbinks", PrayerGroupRole.ADMIN.toString(), 330,
                         "jarjar_binks.jpeg", "https://prayerappfileservices.pythonanywhere.com/45.png",
-                        FileType.IMAGE.toString())
+                        FileType.IMAGE.toString(), OffsetDateTime.now())
         };
 
         Mockito.when(mockPrayerGroupJdbcRepository.getPrayerGroup(anyInt(), anyInt())).thenReturn(mockPrayerGroup);
@@ -274,9 +274,9 @@ public class PrayerGroupServiceTests {
 
         PrayerGroupUserDTO[] prayerGroupUserDTOS = new PrayerGroupUserDTO[]{
                 new PrayerGroupUserDTO(320, "Padme Amidala", "pamidala", PrayerGroupRole.ADMIN.toString(), null, null
-                        , null, null),
+                        , null, null, OffsetDateTime.now()),
                 new PrayerGroupUserDTO(mockUser.getUserId(), "Larry Page", "jpage",
-                        PrayerGroupRole.ADMIN.toString(), null, null, null, null)
+                        PrayerGroupRole.ADMIN.toString(), null, null, null, null, OffsetDateTime.now())
         };
 
         Mockito.when(mockPrayerGroupJdbcRepository.getPrayerGroup(anyInt(), anyInt())).thenReturn(mockUpdatedPrayerGroup);

--- a/src/test/java/com/kevin/prayerappservice/service/PrayerRequestServiceTests.java
+++ b/src/test/java/com/kevin/prayerappservice/service/PrayerRequestServiceTests.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.*;
 
@@ -107,7 +106,7 @@ public class PrayerRequestServiceTests {
         Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
         Mockito.when(jwtService.extractUserId("mockToken")).thenReturn(user.getUserId());
 
-        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, mockPrayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser prayerGroupUser = new PrayerGroupUser(user, mockPrayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser);
 
         PrayerRequestCreateRequest createRequest = new PrayerRequestCreateRequest(1,
@@ -818,8 +817,8 @@ public class PrayerRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Founding Fathers", "Founders of the U.S.", null, VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser1 = new PrayerGroupUser(prayerRequestAuthor, prayerGroup, PrayerGroupRole.MEMBER);
-        PrayerGroupUser prayerGroupUser2 = new PrayerGroupUser(deletePrayerRequestCaller, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser prayerGroupUser1 = new PrayerGroupUser(prayerRequestAuthor, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
+        PrayerGroupUser prayerGroupUser2 = new PrayerGroupUser(deletePrayerRequestCaller, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
 
         prayerGroupUserRepository.save(prayerGroupUser1);
         prayerGroupUserRepository.save(prayerGroupUser2);
@@ -848,8 +847,8 @@ public class PrayerRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Founding Fathers", "Founders of the U.S.", null, VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser1 = new PrayerGroupUser(prayerRequestAuthor, prayerGroup, PrayerGroupRole.MEMBER);
-        PrayerGroupUser prayerGroupUser2 = new PrayerGroupUser(deletePrayerRequestCaller, prayerGroup, PrayerGroupRole.ADMIN);
+        PrayerGroupUser prayerGroupUser1 = new PrayerGroupUser(prayerRequestAuthor, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
+        PrayerGroupUser prayerGroupUser2 = new PrayerGroupUser(deletePrayerRequestCaller, prayerGroup, PrayerGroupRole.ADMIN, OffsetDateTime.now());
 
         prayerGroupUserRepository.save(prayerGroupUser1);
         prayerGroupUserRepository.save(prayerGroupUser2);
@@ -880,7 +879,7 @@ public class PrayerRequestServiceTests {
         PrayerGroup prayerGroup = new PrayerGroup("Founding Fathers", "Founders of the U.S.", null, VisibilityLevel.PRIVATE, null, null);
         prayerGroupRepository.save(prayerGroup);
 
-        PrayerGroupUser prayerGroupUser1 = new PrayerGroupUser(prayerRequestAuthor, prayerGroup, PrayerGroupRole.MEMBER);
+        PrayerGroupUser prayerGroupUser1 = new PrayerGroupUser(prayerRequestAuthor, prayerGroup, PrayerGroupRole.MEMBER, OffsetDateTime.now());
         prayerGroupUserRepository.save(prayerGroupUser1);
 
         OffsetDateTime createdDate = OffsetDateTime.now();


### PR DESCRIPTION
* Add a join_date column to Prayer Group Users
* Add a patch for existing prayer group users - set to today's date
* Added joinDate/createdDate/approvedDate parameters to routes that create prayer group users
* Added join dates to get prayer group and get prayer group user routes
* Sort prayer groups by added date
* Sorted prayer groups in user summaries - Order by join status (joined first), then join date ascending

<img width="1047" height="891" alt="image" src="https://github.com/user-attachments/assets/ee485d26-9052-4a56-91e6-c2ae507b8b89" />
