### PR TITLE
Add Excluded Creator User Ids And Better Null Handling

### DIFF
--- a/src/main/java/com/kevin/prayerappservice/exceptions/ErrorHandler.java
+++ b/src/main/java/com/kevin/prayerappservice/exceptions/ErrorHandler.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import java.util.Optional;
 import java.util.Set;
 
 @ControllerAdvice

--- a/src/main/java/com/kevin/prayerappservice/exceptions/ErrorHandler.java
+++ b/src/main/java/com/kevin/prayerappservice/exceptions/ErrorHandler.java
@@ -7,11 +7,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.Optional;
 import java.util.Set;
 
 @ControllerAdvice
@@ -93,6 +96,24 @@ public class ErrorHandler {
                 .url(request.getRequestURL().toString())
                 .build();
         return new ResponseEntity<>(error, exception.getHttpStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Error> handleMethodArgumentNotValidException(HttpServletRequest request, MethodArgumentNotValidException exception){
+        logger.error("Method argument validation error occurred.", exception);
+
+        ProblemDetail problemDetail = exception.getBody();
+        String message = problemDetail.getDetail();
+
+        DataValidationError error = DataValidationError.dataValidationErrorBuilder()
+                .dataValidationErrors(new String[] { message })
+                .errorCode(ErrorCode.DATA_VALIDATION_ERROR.getErrCode())
+                .message(ErrorCode.DATA_VALIDATION_ERROR.getErrMessageKey())
+                .reqMethod(request.getMethod())
+                .url(request.getRequestURL().toString())
+                .build();
+
+        return new ResponseEntity<Error>(error, HttpStatus.BAD_REQUEST);
     }
 
 

--- a/src/main/java/com/kevin/prayerappservice/request/PrayerRequestJdbcRepositoryImpl.java
+++ b/src/main/java/com/kevin/prayerappservice/request/PrayerRequestJdbcRepositoryImpl.java
@@ -25,7 +25,7 @@ public class PrayerRequestJdbcRepositoryImpl implements PrayerRequestJdbcReposit
 
     @Override
     public List<PrayerRequestGetResult> getPrayerRequests(PrayerRequestGetQuery getQuery){
-        String sql = "SELECT * FROM get_prayer_requests(:targetUserId, :prayerGroupIds, :creatorUserIds, :bookmarkedUserId, :includeExpired, :sortField, :sortDirection, :skip, :take);";
+        String sql = "SELECT * FROM get_prayer_requests(:targetUserId, :prayerGroupIds, :creatorUserIds, :bookmarkedUserId, :includeExpired, :sortField, :sortDirection, :skip, :take, :excludedCreatorUserIds);";
         BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(getQuery);
         return jdbcTemplate.query(sql, params, new BeanPropertyRowMapper<>(PrayerRequestGetResult.class));
     }

--- a/src/main/java/com/kevin/prayerappservice/request/PrayerRequestJdbcRepositoryImpl.java
+++ b/src/main/java/com/kevin/prayerappservice/request/PrayerRequestJdbcRepositoryImpl.java
@@ -32,7 +32,7 @@ public class PrayerRequestJdbcRepositoryImpl implements PrayerRequestJdbcReposit
 
     @Override
     public PrayerRequestCountResult getPrayerRequestsCount(PrayerRequestCountQuery countQuery){
-        String sql = "SELECT * FROM get_prayer_requests_count(:targetUserId, :prayerGroupIds, :creatorUserIds, :bookmarkedUserId, :includeExpired);";
+        String sql = "SELECT * FROM get_prayer_requests_count(:prayerGroupIds, :creatorUserIds, :bookmarkedUserId, :includeExpired, :excludedCreatorUserIds);";
         BeanPropertySqlParameterSource params = new BeanPropertySqlParameterSource(countQuery);
         return jdbcTemplate.queryForObject(sql, params, new BeanPropertyRowMapper<>(PrayerRequestCountResult.class));
     }

--- a/src/main/java/com/kevin/prayerappservice/request/PrayerRequestService.java
+++ b/src/main/java/com/kevin/prayerappservice/request/PrayerRequestService.java
@@ -72,11 +72,30 @@ public class PrayerRequestService {
             int pageSize = filterCriteria.getPageSize();
 
             int[] prayerGroupIds = filterCriteria.getPrayerGroupIds().stream().mapToInt(Integer::valueOf).toArray();
+            int[] excludedCreatorUserIds = filterCriteria.getExcludedCreatorUserIds().stream().mapToInt(Integer::valueOf).toArray();
 
-            PrayerRequestCountQuery countQuery = new PrayerRequestCountQuery(userId, prayerGroupIds, null, null, filterCriteria.isIncludeExpiredPrayerRequests());
+            PrayerRequestCountQuery countQuery = new PrayerRequestCountQuery(
+                    userId,
+                    prayerGroupIds,
+                    null,
+                    null,
+                    filterCriteria.isIncludeExpiredPrayerRequests(),
+                    excludedCreatorUserIds
+            );
+
             PrayerRequestCountResult countResult = prayerRequestRepository.getPrayerRequestsCount(countQuery);
 
-            PrayerRequestGetQuery getQuery = new PrayerRequestGetQuery(userId, prayerGroupIds, null, null, filterCriteria.isIncludeExpiredPrayerRequests(), filterCriteria.getSortConfig().getSortField().toString(), filterCriteria.getSortConfig().getSortDirection().toString(), pageIndex * pageSize, pageSize);
+            PrayerRequestGetQuery getQuery = new PrayerRequestGetQuery(
+                    userId,
+                    prayerGroupIds,
+                    null,
+                    null,
+                    filterCriteria.isIncludeExpiredPrayerRequests(),
+                    filterCriteria.getSortConfig().getSortField().toString(),
+                    filterCriteria.getSortConfig().getSortDirection().toString(),
+                    pageIndex * pageSize, pageSize,
+                    excludedCreatorUserIds
+            );
 
             List<PrayerRequestGetResult> getResults = prayerRequestRepository.getPrayerRequests(getQuery);
 

--- a/src/main/java/com/kevin/prayerappservice/request/PrayerRequestService.java
+++ b/src/main/java/com/kevin/prayerappservice/request/PrayerRequestService.java
@@ -75,7 +75,6 @@ public class PrayerRequestService {
             int[] excludedCreatorUserIds = filterCriteria.getExcludedCreatorUserIds().stream().mapToInt(Integer::valueOf).toArray();
 
             PrayerRequestCountQuery countQuery = new PrayerRequestCountQuery(
-                    userId,
                     prayerGroupIds,
                     null,
                     null,

--- a/src/main/java/com/kevin/prayerappservice/request/PrayerRequestService.java
+++ b/src/main/java/com/kevin/prayerappservice/request/PrayerRequestService.java
@@ -71,8 +71,11 @@ public class PrayerRequestService {
             int pageIndex = filterCriteria.getPageIndex();
             int pageSize = filterCriteria.getPageSize();
 
-            int[] prayerGroupIds = filterCriteria.getPrayerGroupIds().stream().mapToInt(Integer::valueOf).toArray();
-            int[] excludedCreatorUserIds = filterCriteria.getExcludedCreatorUserIds().stream().mapToInt(Integer::valueOf).toArray();
+            List<Integer> requestPrayerGroupIds = Optional.ofNullable(filterCriteria.getPrayerGroupIds()).orElse(new ArrayList<>());
+            List<Integer> requestExcludedCreatorIds = Optional.ofNullable(filterCriteria.getExcludedCreatorUserIds()).orElse(new ArrayList<>());
+
+            int[] prayerGroupIds = requestPrayerGroupIds.stream().mapToInt(Integer::valueOf).toArray();
+            int[] excludedCreatorUserIds =  requestExcludedCreatorIds.stream().mapToInt(Integer::valueOf).toArray();
 
             PrayerRequestCountQuery countQuery = new PrayerRequestCountQuery(
                     prayerGroupIds,

--- a/src/main/java/com/kevin/prayerappservice/request/dtos/PrayerRequestCountQuery.java
+++ b/src/main/java/com/kevin/prayerappservice/request/dtos/PrayerRequestCountQuery.java
@@ -6,13 +6,15 @@ public class PrayerRequestCountQuery {
     private int[] creatorUserIds;
     private Integer bookmarkedUserId;
     private boolean includeExpired;
+    private int[] excludedCreatorUserIds;
 
-    public PrayerRequestCountQuery(int targetUserId, int[] prayerGroupIds, int[] creatorUserIds, Integer bookmarkedUserId, boolean includeExpired) {
+    public PrayerRequestCountQuery(int targetUserId, int[] prayerGroupIds, int[] creatorUserIds, Integer bookmarkedUserId, boolean includeExpired, int[] excludedCreatorUserIds) {
         this.targetUserId = targetUserId;
         this.prayerGroupIds = prayerGroupIds;
         this.creatorUserIds = creatorUserIds;
         this.bookmarkedUserId = bookmarkedUserId;
         this.includeExpired = includeExpired;
+        this.excludedCreatorUserIds = excludedCreatorUserIds;
     }
 
     public int getTargetUserId() {
@@ -53,5 +55,13 @@ public class PrayerRequestCountQuery {
 
     public void setIncludeExpired(boolean includeExpired) {
         this.includeExpired = includeExpired;
+    }
+
+    public int[] getExcludedCreatorUserIds() {
+        return excludedCreatorUserIds;
+    }
+
+    public void setExcludedCreatorUserIds(int[] excludedCreatorUserIds) {
+        this.excludedCreatorUserIds = excludedCreatorUserIds;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/request/dtos/PrayerRequestCountQuery.java
+++ b/src/main/java/com/kevin/prayerappservice/request/dtos/PrayerRequestCountQuery.java
@@ -1,28 +1,18 @@
 package com.kevin.prayerappservice.request.dtos;
 
 public class PrayerRequestCountQuery {
-    private int targetUserId;
     private int[] prayerGroupIds;
     private int[] creatorUserIds;
     private Integer bookmarkedUserId;
     private boolean includeExpired;
     private int[] excludedCreatorUserIds;
 
-    public PrayerRequestCountQuery(int targetUserId, int[] prayerGroupIds, int[] creatorUserIds, Integer bookmarkedUserId, boolean includeExpired, int[] excludedCreatorUserIds) {
-        this.targetUserId = targetUserId;
+    public PrayerRequestCountQuery(int[] prayerGroupIds, int[] creatorUserIds, Integer bookmarkedUserId, boolean includeExpired, int[] excludedCreatorUserIds) {
         this.prayerGroupIds = prayerGroupIds;
         this.creatorUserIds = creatorUserIds;
         this.bookmarkedUserId = bookmarkedUserId;
         this.includeExpired = includeExpired;
         this.excludedCreatorUserIds = excludedCreatorUserIds;
-    }
-
-    public int getTargetUserId() {
-        return targetUserId;
-    }
-
-    public void setTargetUserId(int targetUserId) {
-        this.targetUserId = targetUserId;
     }
 
     public int[] getPrayerGroupIds() {

--- a/src/main/java/com/kevin/prayerappservice/request/dtos/PrayerRequestGetQuery.java
+++ b/src/main/java/com/kevin/prayerappservice/request/dtos/PrayerRequestGetQuery.java
@@ -10,10 +10,11 @@ public class PrayerRequestGetQuery {
     private String sortDirection;
     private int skip;
     private int take;
+    private int[] excludedCreatorUserIds;
 
     public PrayerRequestGetQuery(){}
 
-    public PrayerRequestGetQuery(int targetUserId, int[] prayerGroupIds, int[] creatorUserIds, Integer bookmarkedUserId, boolean includeExpired, String sortField, String sortDirection, int skip, int take) {
+    public PrayerRequestGetQuery(int targetUserId, int[] prayerGroupIds, int[] creatorUserIds, Integer bookmarkedUserId, boolean includeExpired, String sortField, String sortDirection, int skip, int take, int[] excludedCreatorUserIds) {
         this.targetUserId = targetUserId;
         this.prayerGroupIds = prayerGroupIds;
         this.creatorUserIds = creatorUserIds;
@@ -23,6 +24,7 @@ public class PrayerRequestGetQuery {
         this.sortDirection = sortDirection;
         this.skip = skip;
         this.take = take;
+        this.excludedCreatorUserIds = excludedCreatorUserIds;
     }
 
     public int getTargetUserId() {
@@ -95,5 +97,13 @@ public class PrayerRequestGetQuery {
 
     public void setTake(int take) {
         this.take = take;
+    }
+
+    public int[] getExcludedCreatorUserIds() {
+        return excludedCreatorUserIds;
+    }
+
+    public void setExcludedCreatorUserIds(int[] excludedCreatorUserIds) {
+        this.excludedCreatorUserIds = excludedCreatorUserIds;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
+++ b/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
@@ -1,15 +1,22 @@
 package com.kevin.prayerappservice.request.models;
 
 import com.kevin.prayerappservice.common.SortConfig;
+import com.kevin.prayerappservice.common.SortDirection;
 import com.kevin.prayerappservice.request.constants.PrayerRequestSortField;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public class PrayerRequestFilterCriteria {
     private List<Integer> prayerGroupIds;
-    private Integer pageIndex;
-    private Integer pageSize;
-    private SortConfig<PrayerRequestSortField> sortConfig;
+    @NotNull
+    private int pageIndex;
+
+    @NotNull
+    private int pageSize;
+
+    private SortConfig<PrayerRequestSortField> sortConfig = new SortConfig<>(PrayerRequestSortField.CREATED_DATE, SortDirection.DESCENDING);
+
     private boolean includeExpiredPrayerRequests = false;
     private List<Integer> excludedCreatorUserIds;
 

--- a/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
+++ b/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
@@ -11,15 +11,17 @@ public class PrayerRequestFilterCriteria {
     private Integer pageSize;
     private SortConfig<PrayerRequestSortField> sortConfig;
     private boolean includeExpiredPrayerRequests = false;
+    private List<Integer> excludedCreatorUserIds;
 
     public PrayerRequestFilterCriteria(){}
 
-    public PrayerRequestFilterCriteria(List<Integer> prayerGroupIds, Integer pageIndex, Integer pageSize, SortConfig<PrayerRequestSortField> sortConfig, boolean includeExpiredPrayerRequests) {
+    public PrayerRequestFilterCriteria(List<Integer> prayerGroupIds, Integer pageIndex, Integer pageSize, SortConfig<PrayerRequestSortField> sortConfig, boolean includeExpiredPrayerRequests, List<Integer> excludedCreatorUserIds) {
         this.prayerGroupIds = prayerGroupIds;
         this.pageIndex = pageIndex;
         this.pageSize = pageSize;
         this.sortConfig = sortConfig;
         this.includeExpiredPrayerRequests = includeExpiredPrayerRequests;
+        this.excludedCreatorUserIds = excludedCreatorUserIds;
     }
 
     public List<Integer> getPrayerGroupIds() {
@@ -60,5 +62,13 @@ public class PrayerRequestFilterCriteria {
 
     public void setIncludeExpiredPrayerRequests(boolean includeExpiredPrayerRequests) {
         this.includeExpiredPrayerRequests = includeExpiredPrayerRequests;
+    }
+
+    public List<Integer> getExcludedCreatorUserIds() {
+        return excludedCreatorUserIds;
+    }
+
+    public void setExcludedCreatorUserIds(List<Integer> excludedCreatorUserIds) {
+        this.excludedCreatorUserIds = excludedCreatorUserIds;
     }
 }

--- a/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
+++ b/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
@@ -26,9 +26,12 @@ public class PrayerRequestFilterCriteria {
         this.prayerGroupIds = prayerGroupIds;
         this.pageIndex = pageIndex;
         this.pageSize = pageSize;
-        this.sortConfig = sortConfig;
         this.includeExpiredPrayerRequests = includeExpiredPrayerRequests;
         this.excludedCreatorUserIds = excludedCreatorUserIds;
+
+        if(sortConfig != null){
+            this.sortConfig = sortConfig;
+        }
     }
 
     public List<Integer> getPrayerGroupIds() {

--- a/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
+++ b/src/main/java/com/kevin/prayerappservice/request/models/PrayerRequestFilterCriteria.java
@@ -10,10 +10,10 @@ import java.util.List;
 public class PrayerRequestFilterCriteria {
     private List<Integer> prayerGroupIds;
     @NotNull
-    private int pageIndex;
+    private Integer pageIndex;
 
     @NotNull
-    private int pageSize;
+    private Integer pageSize;
 
     private SortConfig<PrayerRequestSortField> sortConfig = new SortConfig<>(PrayerRequestSortField.CREATED_DATE, SortDirection.DESCENDING);
 

--- a/src/main/resources/db/migration/V2_59__get_prayer_request_count_excluded_ids.sql
+++ b/src/main/resources/db/migration/V2_59__get_prayer_request_count_excluded_ids.sql
@@ -1,0 +1,30 @@
+DROP FUNCTION get_prayer_requests_count;
+
+CREATE OR REPLACE FUNCTION get_prayer_requests_count (
+    p_prayer_group_ids INT[],
+    p_creator_user_ids INT[],
+    p_bookmarked_user_id INT,
+    p_include_expired BOOLEAN,
+    p_excluded_creator_user_ids INT[]
+) RETURNS TABLE (
+    prayer_request_count BIGINT
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+        SELECT
+            COUNT(r.prayer_request_id) AS prayer_request_count
+        FROM
+            prayer_request r
+        LEFT JOIN
+            prayer_request_bookmark b ON b.prayer_request_id = r.prayer_request_id
+        WHERE
+            (p_prayer_group_ids IS NULL OR r.prayer_group_id = ANY(p_prayer_group_ids))
+            AND (p_creator_user_ids IS NULL OR r.user_id = ANY(p_creator_user_ids))
+            AND (p_bookmarked_user_id IS NULL OR b.user_id = p_bookmarked_user_id)
+            AND (p_include_expired IS TRUE OR r.expiration_date IS NULL OR r.expiration_date > CURRENT_TIMESTAMP)
+            AND (p_excluded_creator_user_ids IS NULL OR r.user_id != ANY(p_excluded_creator_user_ids));
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_60__get_prayer_requests_excluded_creator_user_ids.sql
+++ b/src/main/resources/db/migration/V2_60__get_prayer_requests_excluded_creator_user_ids.sql
@@ -1,0 +1,141 @@
+DROP FUNCTION get_prayer_requests;
+
+CREATE OR REPLACE FUNCTION get_prayer_requests (
+    p_target_user_id INT,
+    p_prayer_group_ids INT[],
+    p_creator_user_ids INT[],
+    p_bookmarked_user_id INT,
+    p_include_expired BOOLEAN,
+    p_sort_field VARCHAR(255),
+    p_sort_direction VARCHAR(255),
+    p_skip INT,
+    p_take INT,
+    p_excluded_creator_user_ids INT[]
+) RETURNS TABLE (
+    prayer_request_id INT,
+    request_title VARCHAR(255),
+    request_description TEXT,
+    created_date TIMESTAMPTZ,
+    expiration_date TIMESTAMPTZ,
+    like_count INT,
+    comment_count INT,
+    prayed_count INT,
+    user_like_id INT,
+    user_bookmark_id INT,
+    prayer_group_id INT,
+    group_name VARCHAR(255),
+    avatar_file_id INT,
+    avatar_file_name VARCHAR(255),
+    avatar_file_url VARCHAR(255),
+    avatar_file_type VARCHAR(255),
+    user_id INT,
+    username VARCHAR(255),
+    full_name VARCHAR(255),
+    user_file_id INT,
+    user_file_name VARCHAR(255),
+    user_file_url VARCHAR(255),
+    user_file_type VARCHAR(255)
+)
+AS
+$$
+BEGIN
+    DROP TABLE IF EXISTS target_prayer_group_users;
+
+    CREATE TEMPORARY TABLE target_prayer_group_users (
+            prayer_group_user_id INT,
+            prayer_group_id INT,
+            user_id INT
+        );
+
+    INSERT INTO
+        target_prayer_group_users (prayer_group_user_id, prayer_group_id, user_id)
+    SELECT
+        u.prayer_group_user_id, u.prayer_group_id, u.user_id
+    FROM
+        prayer_group_user u
+    WHERE
+        u.user_id = p_target_user_id;
+
+
+    IF EXISTS (
+            SELECT
+                1
+            FROM
+                prayer_group g
+            LEFT JOIN
+                target_prayer_group_users t ON t.prayer_group_id = g.prayer_group_id
+            WHERE
+                g.prayer_group_id = ANY(p_prayer_group_ids) AND g.visibility_level = 'PRIVATE' AND t.user_id IS NULL
+        )
+        THEN
+            RAISE EXCEPTION 'Cannot view prayer requests from private prayer groups without membership.';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        r.prayer_request_id,
+        r.request_title,
+        r.request_description,
+        r.created_date,
+        r.expiration_date,
+        r.like_count,
+        r.comment_count,
+        r.prayed_count,
+        l.prayer_request_like_id,
+        b.prayer_request_bookmark_id,
+        g.prayer_group_id,
+        g.group_name,
+        f1.media_file_id,
+        f1.file_name,
+        f1.file_url,
+        f1.file_type,
+        u.user_id,
+        u.username,
+        u.full_name,
+        f2.media_file_id,
+        f2.file_name,
+        f2.file_url,
+        f2.file_type
+    FROM
+        prayer_request r
+            INNER JOIN
+        prayer_group g ON g.prayer_group_id = r.prayer_group_id
+            INNER JOIN
+        app_user u ON u.user_id = r.user_id
+            LEFT JOIN
+        prayer_request_like l ON l.prayer_request_id = r.prayer_request_id AND l.user_id = p_target_user_id
+            LEFT JOIN
+        prayer_request_bookmark b ON b.prayer_request_id = r.prayer_request_id
+            LEFT JOIN
+        media_file f1 ON f1.media_file_id = g.avatar_file_id
+            LEFT JOIN
+        media_file f2 ON f2.media_file_id = u.image_file_id
+    WHERE
+        (p_prayer_group_ids IS NULL OR r.prayer_group_id = ANY(p_prayer_group_ids))
+      AND (p_creator_user_ids IS NULL OR r.user_id = ANY(p_creator_user_ids))
+      AND (p_bookmarked_user_id IS NULL OR b.user_id = p_bookmarked_user_id)
+      AND (p_include_expired IS TRUE OR r.expiration_date IS NULL OR r.expiration_date > CURRENT_TIMESTAMP)
+      AND (p_excluded_creator_user_ids IS NULL OR r.user_id != ANY(p_excluded_creator_user_ids))
+    ORDER BY
+        CASE WHEN p_sort_field = 'CREATED_DATE' AND p_sort_direction = 'ASCENDING' THEN r.created_date END ASC,
+        CASE WHEN p_sort_field = 'CREATED_DATE' AND p_sort_direction = 'DESCENDING' THEN r.created_date END DESC,
+        CASE WHEN p_sort_field = 'LIKE_COUNT' AND p_sort_direction = 'ASCENDING' THEN r.like_count END ASC,
+        CASE WHEN p_sort_field = 'LIKE_COUNT' AND p_sort_direction = 'DESCENDING' THEN r.like_count END DESC,
+        CASE WHEN p_sort_field = 'COMMENT_COUNT' AND p_sort_direction = 'ASCENDING' THEN r.comment_count END ASC,
+        CASE WHEN p_sort_field = 'COMMENT_COUNT' AND p_sort_direction = 'DESCENDING' THEN r.comment_count END DESC,
+        CASE WHEN p_sort_field = 'PRAYED_COUNT' AND p_sort_direction = 'ASCENDING' THEN r.prayed_count END ASC,
+        CASE WHEN p_sort_field = 'PRAYED_COUNT' AND p_sort_direction = 'DESCENDING' THEN r.prayed_count END DESC
+    OFFSET
+        p_skip
+        LIMIT
+        p_take;
+
+    DROP TABLE IF EXISTS target_prayer_group_users;
+RETURN;
+    EXCEPTION
+        WHEN OTHERS THEN
+            DROP TABLE IF EXISTS target_prayer_group_users;
+            RAISE;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_61__get_prayer_requests_null_checking.sql
+++ b/src/main/resources/db/migration/V2_61__get_prayer_requests_null_checking.sql
@@ -1,0 +1,141 @@
+DROP FUNCTION IF EXISTS get_prayer_requests;
+
+CREATE OR REPLACE FUNCTION get_prayer_requests (
+    p_target_user_id INT,
+    p_prayer_group_ids INT[],
+    p_creator_user_ids INT[],
+    p_bookmarked_user_id INT,
+    p_include_expired BOOLEAN,
+    p_sort_field VARCHAR(255),
+    p_sort_direction VARCHAR(255),
+    p_skip INT,
+    p_take INT,
+    p_excluded_creator_user_ids INT[]
+) RETURNS TABLE (
+    prayer_request_id INT,
+    request_title VARCHAR(255),
+    request_description TEXT,
+    created_date TIMESTAMPTZ,
+    expiration_date TIMESTAMPTZ,
+    like_count INT,
+    comment_count INT,
+    prayed_count INT,
+    user_like_id INT,
+    user_bookmark_id INT,
+    prayer_group_id INT,
+    group_name VARCHAR(255),
+    avatar_file_id INT,
+    avatar_file_name VARCHAR(255),
+    avatar_file_url VARCHAR(255),
+    avatar_file_type VARCHAR(255),
+    user_id INT,
+    username VARCHAR(255),
+    full_name VARCHAR(255),
+    user_file_id INT,
+    user_file_name VARCHAR(255),
+    user_file_url VARCHAR(255),
+    user_file_type VARCHAR(255)
+)
+AS
+$$
+BEGIN
+    DROP TABLE IF EXISTS target_prayer_group_users;
+
+    CREATE TEMPORARY TABLE target_prayer_group_users (
+            prayer_group_user_id INT,
+            prayer_group_id INT,
+            user_id INT
+        );
+
+    INSERT INTO
+        target_prayer_group_users (prayer_group_user_id, prayer_group_id, user_id)
+    SELECT
+        u.prayer_group_user_id, u.prayer_group_id, u.user_id
+    FROM
+        prayer_group_user u
+    WHERE
+        u.user_id = p_target_user_id;
+
+
+    IF EXISTS (
+            SELECT
+                1
+            FROM
+                prayer_group g
+            LEFT JOIN
+                target_prayer_group_users t ON t.prayer_group_id = g.prayer_group_id
+            WHERE
+                g.prayer_group_id = ANY(p_prayer_group_ids) AND g.visibility_level = 'PRIVATE' AND t.user_id IS NULL
+        )
+        THEN
+            RAISE EXCEPTION 'Cannot view prayer requests from private prayer groups without membership.';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        r.prayer_request_id,
+        r.request_title,
+        r.request_description,
+        r.created_date,
+        r.expiration_date,
+        r.like_count,
+        r.comment_count,
+        r.prayed_count,
+        l.prayer_request_like_id,
+        b.prayer_request_bookmark_id,
+        g.prayer_group_id,
+        g.group_name,
+        f1.media_file_id,
+        f1.file_name,
+        f1.file_url,
+        f1.file_type,
+        u.user_id,
+        u.username,
+        u.full_name,
+        f2.media_file_id,
+        f2.file_name,
+        f2.file_url,
+        f2.file_type
+    FROM
+        prayer_request r
+            INNER JOIN
+        prayer_group g ON g.prayer_group_id = r.prayer_group_id
+            INNER JOIN
+        app_user u ON u.user_id = r.user_id
+            LEFT JOIN
+        prayer_request_like l ON l.prayer_request_id = r.prayer_request_id AND l.user_id = p_target_user_id
+            LEFT JOIN
+        prayer_request_bookmark b ON b.prayer_request_id = r.prayer_request_id
+            LEFT JOIN
+        media_file f1 ON f1.media_file_id = g.avatar_file_id
+            LEFT JOIN
+        media_file f2 ON f2.media_file_id = u.image_file_id
+    WHERE
+        (COALESCE(cardinality(p_prayer_group_ids), 0) = 0 OR r.prayer_group_id = ANY(p_prayer_group_ids))
+      AND (COALESCE(cardinality(p_creator_user_ids), 0) = 0 OR r.user_id = ANY(p_creator_user_ids))
+      AND (p_bookmarked_user_id IS NULL OR b.user_id = p_bookmarked_user_id)
+      AND (p_include_expired IS TRUE OR r.expiration_date IS NULL OR r.expiration_date > CURRENT_TIMESTAMP)
+      AND (COALESCE(cardinality(p_excluded_creator_user_ids), 0) = 0 OR r.user_id != ALL(p_excluded_creator_user_ids))
+    ORDER BY
+        CASE WHEN p_sort_field = 'CREATED_DATE' AND p_sort_direction = 'ASCENDING' THEN r.created_date END ASC,
+        CASE WHEN p_sort_field = 'CREATED_DATE' AND p_sort_direction = 'DESCENDING' THEN r.created_date END DESC,
+        CASE WHEN p_sort_field = 'LIKE_COUNT' AND p_sort_direction = 'ASCENDING' THEN r.like_count END ASC,
+        CASE WHEN p_sort_field = 'LIKE_COUNT' AND p_sort_direction = 'DESCENDING' THEN r.like_count END DESC,
+        CASE WHEN p_sort_field = 'COMMENT_COUNT' AND p_sort_direction = 'ASCENDING' THEN r.comment_count END ASC,
+        CASE WHEN p_sort_field = 'COMMENT_COUNT' AND p_sort_direction = 'DESCENDING' THEN r.comment_count END DESC,
+        CASE WHEN p_sort_field = 'PRAYED_COUNT' AND p_sort_direction = 'ASCENDING' THEN r.prayed_count END ASC,
+        CASE WHEN p_sort_field = 'PRAYED_COUNT' AND p_sort_direction = 'DESCENDING' THEN r.prayed_count END DESC
+    OFFSET
+        p_skip
+        LIMIT
+        p_take;
+
+    DROP TABLE IF EXISTS target_prayer_group_users;
+RETURN;
+EXCEPTION
+    WHEN OTHERS THEN
+        DROP TABLE IF EXISTS target_prayer_group_users;
+        RAISE;
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/main/resources/db/migration/V2_62__get_prayer_Requests_count_null_checking.sql
+++ b/src/main/resources/db/migration/V2_62__get_prayer_Requests_count_null_checking.sql
@@ -1,0 +1,30 @@
+DROP FUNCTION get_prayer_requests_count;
+
+CREATE OR REPLACE FUNCTION get_prayer_requests_count (
+    p_prayer_group_ids INT[],
+    p_creator_user_ids INT[],
+    p_bookmarked_user_id INT,
+    p_include_expired BOOLEAN,
+    p_excluded_creator_user_ids INT[]
+) RETURNS TABLE (
+    prayer_request_count BIGINT
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+    SELECT
+        COUNT(r.prayer_request_id) AS prayer_request_count
+    FROM
+        prayer_request r
+            LEFT JOIN
+        prayer_request_bookmark b ON b.prayer_request_id = r.prayer_request_id
+    WHERE
+        (COALESCE(cardinality(p_prayer_group_ids), 0) = 0 OR r.prayer_group_id = ANY(p_prayer_group_ids))
+      AND (COALESCE(cardinality(p_creator_user_ids), 0) = 0 OR r.user_id = ANY(p_creator_user_ids))
+      AND (p_bookmarked_user_id IS NULL OR b.user_id = p_bookmarked_user_id)
+      AND (p_include_expired IS TRUE OR r.expiration_date IS NULL OR r.expiration_date > CURRENT_TIMESTAMP)
+      AND (COALESCE(cardinality(p_excluded_creator_user_ids), 0) = 0 OR r.user_id != ALL(p_excluded_creator_user_ids));
+END;
+$$
+LANGUAGE plpgsql;

--- a/src/test/java/com/kevin/prayerappservice/PrayerappserviceApplicationTests.java
+++ b/src/test/java/com/kevin/prayerappservice/PrayerappserviceApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("dev")
+@ActiveProfiles("test")
 @SpringBootTest
 class PrayerAppServiceApplicationTests {
 

--- a/src/test/java/com/kevin/prayerappservice/service/PrayerRequestServiceTests.java
+++ b/src/test/java/com/kevin/prayerappservice/service/PrayerRequestServiceTests.java
@@ -897,4 +897,92 @@ public class PrayerRequestServiceTests {
 
         Assertions.assertThat(prayerRequestIdToDelete.getValue()).isEqualTo(prayerRequest.getPrayerRequestId());
     }
+
+    @Test
+    public void getPrayerRequests_withExcludedUserIds_callsRepositoryWithIds(){
+        SortConfig<PrayerRequestSortField> sortConfig = new SortConfig<>(PrayerRequestSortField.CREATED_DATE, SortDirection.DESCENDING);
+        List<Integer> prayerGroupIds = List.of(747);
+        List<Integer> excludedCreatorUserIds = List.of(787);
+
+        PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 2, sortConfig, false, excludedCreatorUserIds);
+
+        Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
+        Mockito.when(jwtService.extractUserId(anyString())).thenReturn(737);
+
+        PrayerRequestCountResult countResult = new PrayerRequestCountResult(20);
+
+        Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(countResult);
+
+        OffsetDateTime currentTime = OffsetDateTime.now();
+
+        PrayerRequestGetResult prayerRequest1 = new PrayerRequestGetResult(767, "Prayer Request 1", "Prayer Request 1 Description", currentTime, currentTime.plusDays(15));
+        PrayerRequestGetResult prayerRequest2 = new PrayerRequestGetResult(777, "Prayer Request 2", "Prayer Request 2 Description", currentTime, currentTime.plusDays(15));
+
+        Mockito.when(prayerRequestJdbcRepository.getPrayerRequests(any())).thenReturn(List.of(prayerRequest1, prayerRequest2));
+
+        prayerRequestService.getPrayerRequests("mockAuthHeader", filterCriteria);
+
+        ArgumentCaptor<PrayerRequestGetQuery> getQueryArgumentCaptor = ArgumentCaptor.forClass(PrayerRequestGetQuery.class);
+        Mockito.verify(prayerRequestJdbcRepository).getPrayerRequests(getQueryArgumentCaptor.capture());
+
+        Assertions.assertThat(getQueryArgumentCaptor.getValue().getExcludedCreatorUserIds()[0]).isEqualTo(excludedCreatorUserIds.getFirst());
+    }
+
+    @Test
+    public void getPrayerRequests_withEmptyExcludedUserIds_callsRepositoryWithoutExcludedIds(){
+        SortConfig<PrayerRequestSortField> sortConfig = new SortConfig<>(PrayerRequestSortField.CREATED_DATE, SortDirection.DESCENDING);
+        List<Integer> prayerGroupIds = List.of(747);
+
+        PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 2, sortConfig, false, null);
+
+        Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
+        Mockito.when(jwtService.extractUserId(anyString())).thenReturn(737);
+
+        PrayerRequestCountResult countResult = new PrayerRequestCountResult(20);
+
+        Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(countResult);
+
+        OffsetDateTime currentTime = OffsetDateTime.now();
+
+        PrayerRequestGetResult prayerRequest1 = new PrayerRequestGetResult(767, "Prayer Request 1", "Prayer Request 1 Description", currentTime, currentTime.plusDays(15));
+        PrayerRequestGetResult prayerRequest2 = new PrayerRequestGetResult(777, "Prayer Request 2", "Prayer Request 2 Description", currentTime, currentTime.plusDays(15));
+
+        Mockito.when(prayerRequestJdbcRepository.getPrayerRequests(any())).thenReturn(List.of(prayerRequest1, prayerRequest2));
+
+        prayerRequestService.getPrayerRequests("mockAuthHeader", filterCriteria);
+
+        ArgumentCaptor<PrayerRequestGetQuery> getQueryArgumentCaptor = ArgumentCaptor.forClass(PrayerRequestGetQuery.class);
+        Mockito.verify(prayerRequestJdbcRepository).getPrayerRequests(getQueryArgumentCaptor.capture());
+
+        Assertions.assertThat(getQueryArgumentCaptor.getValue().getExcludedCreatorUserIds().length).isEqualTo(0);
+    }
+
+    @Test
+    public void getPrayerRequests_withNullSort_usesDefaultSort(){
+        List<Integer> prayerGroupIds = List.of(747);
+
+        PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 2, null, false, null);
+
+        Mockito.when(jwtService.extractTokenFromAuthHeader(anyString())).thenReturn("mockToken");
+        Mockito.when(jwtService.extractUserId(anyString())).thenReturn(737);
+
+        PrayerRequestCountResult countResult = new PrayerRequestCountResult(20);
+
+        Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(countResult);
+
+        OffsetDateTime currentTime = OffsetDateTime.now();
+
+        PrayerRequestGetResult prayerRequest1 = new PrayerRequestGetResult(767, "Prayer Request 1", "Prayer Request 1 Description", currentTime, currentTime.plusDays(15));
+        PrayerRequestGetResult prayerRequest2 = new PrayerRequestGetResult(777, "Prayer Request 2", "Prayer Request 2 Description", currentTime, currentTime.plusDays(15));
+
+        Mockito.when(prayerRequestJdbcRepository.getPrayerRequests(any())).thenReturn(List.of(prayerRequest1, prayerRequest2));
+
+        prayerRequestService.getPrayerRequests("mockAuthHeader", filterCriteria);
+
+        ArgumentCaptor<PrayerRequestGetQuery> getQueryArgumentCaptor = ArgumentCaptor.forClass(PrayerRequestGetQuery.class);
+        Mockito.verify(prayerRequestJdbcRepository).getPrayerRequests(getQueryArgumentCaptor.capture());
+
+        Assertions.assertThat(getQueryArgumentCaptor.getValue().getSortField()).isEqualTo(PrayerRequestSortField.CREATED_DATE.toString());
+        Assertions.assertThat(getQueryArgumentCaptor.getValue().getSortDirection()).isEqualTo(SortDirection.DESCENDING.toString());
+    }
 }

--- a/src/test/java/com/kevin/prayerappservice/service/PrayerRequestServiceTests.java
+++ b/src/test/java/com/kevin/prayerappservice/service/PrayerRequestServiceTests.java
@@ -138,7 +138,7 @@ public class PrayerRequestServiceTests {
                 SortDirection.DESCENDING);
 
         PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 20,
-                sortConfig, false);
+                sortConfig, false, null);
 
         Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(new PrayerRequestCountResult(100));
         Mockito.when(prayerRequestJdbcRepository.getPrayerRequests(any())).thenThrow(new UncategorizedSQLException(null, null, new SQLException(PrayerRequestErrors.USER_MUST_BE_JOINED_TO_VIEW)));
@@ -156,7 +156,7 @@ public class PrayerRequestServiceTests {
                 SortDirection.DESCENDING);
 
         PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 20,
-                sortConfig, false);
+                sortConfig, false, null);
 
         Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(new PrayerRequestCountResult(100));
 
@@ -184,7 +184,7 @@ public class PrayerRequestServiceTests {
                 SortDirection.DESCENDING);
 
         PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 20,
-                sortConfig, false);
+                sortConfig, false, null);
 
         Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(new PrayerRequestCountResult(100));
 
@@ -221,7 +221,7 @@ public class PrayerRequestServiceTests {
                 SortDirection.DESCENDING);
 
         PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 20,
-                sortConfig, false);
+                sortConfig, false, null);
 
         Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(new PrayerRequestCountResult(100));
 
@@ -263,7 +263,7 @@ public class PrayerRequestServiceTests {
                 SortDirection.DESCENDING);
 
         PrayerRequestFilterCriteria filterCriteria = new PrayerRequestFilterCriteria(prayerGroupIds, 0, 20,
-                sortConfig, false);
+                sortConfig, false, null);
 
         Mockito.when(prayerRequestJdbcRepository.getPrayerRequestsCount(any())).thenReturn(new PrayerRequestCountResult(100));
 


### PR DESCRIPTION
* Add Excuded Creator User Ids to Prayer Requests GET Route - This is so we can filter out the signed in user for the home feed
* Add better null handing for the Prayer Requests GET Route - Add a default Sort Config, add handling for null arrays in the filter criteria
* Fix issue where get_prayer_request() stored procedure wasn't returning any values if arrays were empty rather than null
* Removed dead target_user_id parameter from get_prayer_requests_count()